### PR TITLE
Make sure httpurlconnection-executor treats headers in a case-insenit…

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectCodeStyleSettingsManager">
+    <option name="PER_PROJECT_SETTINGS">
+      <value>
+        <XML>
+          <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+        </XML>
+      </value>
+    </option>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="dmfs" />
+  </component>
+</project>

--- a/.idea/modules/http-client-basics/http-client-basics.iml
+++ b/.idea/modules/http-client-basics/http-client-basics.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-basics" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-basics" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-basics">

--- a/.idea/modules/http-client-basics/http-client-basics_main.iml
+++ b/.idea/modules/http-client-basics/http-client-basics_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-basics:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-basics:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/../../../http-client-basics/build/classes/main" />
     <exclude-output />

--- a/.idea/modules/http-client-basics/http-client-basics_test.iml
+++ b/.idea/modules/http-client-basics/http-client-basics_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-basics:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-basics:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output-test url="file://$MODULE_DIR$/../../../http-client-basics/build/classes/test" />
     <exclude-output />

--- a/.idea/modules/http-client-essentials-suite.iml
+++ b/.idea/modules/http-client-essentials-suite.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="http-client-essentials-suite" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="http-client-essentials-suite" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../..">

--- a/.idea/modules/http-client-essentials-suite_main.iml
+++ b/.idea/modules/http-client-essentials-suite_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="http-client-essentials-suite:main" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="http-client-essentials-suite:main" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/../../build/classes/main" />
     <exclude-output />

--- a/.idea/modules/http-client-essentials-suite_test.iml
+++ b/.idea/modules/http-client-essentials-suite_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="http-client-essentials-suite:test" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="http-client-essentials-suite:test" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output-test url="file://$MODULE_DIR$/../../build/classes/test" />
     <exclude-output />

--- a/.idea/modules/http-client-essentials/http-client-essentials.iml
+++ b/.idea/modules/http-client-essentials/http-client-essentials.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-essentials" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-essentials" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-essentials">

--- a/.idea/modules/http-client-essentials/http-client-essentials_main.iml
+++ b/.idea/modules/http-client-essentials/http-client-essentials_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-essentials:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-essentials:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/../../../http-client-essentials/build/classes/main" />
     <exclude-output />

--- a/.idea/modules/http-client-essentials/http-client-essentials_test.iml
+++ b/.idea/modules/http-client-essentials/http-client-essentials_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-essentials:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-essentials:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output-test url="file://$MODULE_DIR$/../../../http-client-essentials/build/classes/test" />
     <exclude-output />

--- a/.idea/modules/http-client-headers/http-client-headers.iml
+++ b/.idea/modules/http-client-headers/http-client-headers.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-headers" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-headers" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-headers">

--- a/.idea/modules/http-client-headers/http-client-headers_main.iml
+++ b/.idea/modules/http-client-headers/http-client-headers_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-headers:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-headers:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/../../../http-client-headers/build/classes/main" />
     <exclude-output />

--- a/.idea/modules/http-client-headers/http-client-headers_test.iml
+++ b/.idea/modules/http-client-headers/http-client-headers_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-headers:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-headers:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output-test url="file://$MODULE_DIR$/../../../http-client-headers/build/classes/test" />
     <exclude-output />

--- a/.idea/modules/http-client-mockutils/http-client-mockutils.iml
+++ b/.idea/modules/http-client-mockutils/http-client-mockutils.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-mockutils" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-mockutils" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-mockutils">

--- a/.idea/modules/http-client-mockutils/http-client-mockutils_main.iml
+++ b/.idea/modules/http-client-mockutils/http-client-mockutils_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-mockutils:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-mockutils:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/../../../http-client-mockutils/build/classes/main" />
     <exclude-output />
@@ -11,8 +11,8 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="http-client-essentials_main" />
     <orderEntry type="module" module-name="http-client-headers_main" />
+    <orderEntry type="module" module-name="http-client-basics_main" />
     <orderEntry type="module" module-name="http-client-types_main" />
     <orderEntry type="library" name="Gradle: org.dmfs:iterators:1.3" level="project" />
-    <orderEntry type="module" module-name="http-client-basics_main" />
   </component>
 </module>

--- a/.idea/modules/http-client-mockutils/http-client-mockutils_test.iml
+++ b/.idea/modules/http-client-mockutils/http-client-mockutils_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-mockutils:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-mockutils:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output-test url="file://$MODULE_DIR$/../../../http-client-mockutils/build/classes/test" />
     <exclude-output />
@@ -12,6 +12,7 @@
     <orderEntry type="module" module-name="http-client-mockutils_main" />
     <orderEntry type="module" module-name="http-client-essentials_main" />
     <orderEntry type="module" module-name="http-client-headers_main" />
+    <orderEntry type="module" module-name="http-client-basics_main" />
     <orderEntry type="library" name="Gradle: junit:junit:4.11" level="project" />
     <orderEntry type="module" module-name="http-client-types_main" />
     <orderEntry type="library" name="Gradle: org.dmfs:iterators:1.3" level="project" />

--- a/.idea/modules/http-client-types/http-client-types.iml
+++ b/.idea/modules/http-client-types/http-client-types.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-types" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-types" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-types">

--- a/.idea/modules/http-client-types/http-client-types_main.iml
+++ b/.idea/modules/http-client-types/http-client-types_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-types:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-types:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/../../../http-client-types/build/classes/main" />
     <exclude-output />

--- a/.idea/modules/http-client-types/http-client-types_test.iml
+++ b/.idea/modules/http-client-types/http-client-types_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-types:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-types:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output-test url="file://$MODULE_DIR$/../../../http-client-types/build/classes/test" />
     <exclude-output />

--- a/.idea/modules/http-executor-decorators/http-executor-decorators.iml
+++ b/.idea/modules/http-executor-decorators/http-executor-decorators.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-executor-decorators" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-executor-decorators" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-executor-decorators">

--- a/.idea/modules/http-executor-decorators/http-executor-decorators_main.iml
+++ b/.idea/modules/http-executor-decorators/http-executor-decorators_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-executor-decorators:main" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-executor-decorators:main" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/../../../http-executor-decorators/build/classes/main" />
     <exclude-output />

--- a/.idea/modules/http-executor-decorators/http-executor-decorators_test.iml
+++ b/.idea/modules/http-executor-decorators/http-executor-decorators_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-executor-decorators:test" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-executor-decorators:test" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output-test url="file://$MODULE_DIR$/../../../http-executor-decorators/build/classes/test" />
     <exclude-output />
@@ -16,9 +16,9 @@
     <orderEntry type="module" module-name="http-client-basics_main" />
     <orderEntry type="library" name="Gradle: junit:junit:4.11" level="project" />
     <orderEntry type="library" name="Gradle: org.jmockit:jmockit:1.26" level="project" />
+    <orderEntry type="module" module-name="http-client-mockutils_main" />
     <orderEntry type="library" name="Gradle: org.dmfs:iterators:1.3" level="project" />
     <orderEntry type="library" name="Gradle: org.hamcrest:hamcrest-core:1.3" level="project" />
-    <orderEntry type="module" module-name="http-client-mockutils_main" scope="TEST" />
   </component>
   <component name="TestModuleProperties" production-module="http-executor-decorators_main" />
 </module>

--- a/.idea/modules/httpurlconnection-executor/httpurlconnection-executor.iml
+++ b/.idea/modules/httpurlconnection-executor/httpurlconnection-executor.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":httpurlconnection-executor" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":httpurlconnection-executor" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../httpurlconnection-executor">

--- a/.idea/modules/httpurlconnection-executor/httpurlconnection-executor_main.iml
+++ b/.idea/modules/httpurlconnection-executor/httpurlconnection-executor_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":httpurlconnection-executor:main" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":httpurlconnection-executor:main" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/../../../httpurlconnection-executor/build/classes/main" />
     <exclude-output />
@@ -14,6 +14,7 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="http-client-essentials_main" />
     <orderEntry type="module" module-name="http-client-types_main" />
+    <orderEntry type="module" module-name="http-client-headers_main" />
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
@@ -23,7 +24,8 @@
         <SOURCES />
       </library>
     </orderEntry>
-    <orderEntry type="module" module-name="http-client-headers_main" />
+    <orderEntry type="module" module-name="http-client-basics_main" />
+    <orderEntry type="library" name="Gradle: org.mockito:mockito-all:1.9.5" level="project" />
     <orderEntry type="library" name="Gradle: org.dmfs:iterators:1.3" level="project" />
     <orderEntry type="module-library">
       <library>
@@ -34,6 +36,5 @@
         <SOURCES />
       </library>
     </orderEntry>
-    <orderEntry type="module" module-name="http-client-basics_main" />
   </component>
 </module>

--- a/.idea/modules/httpurlconnection-executor/httpurlconnection-executor_test.iml
+++ b/.idea/modules/httpurlconnection-executor/httpurlconnection-executor_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":httpurlconnection-executor:test" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.9-6-gfd77267" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":httpurlconnection-executor:test" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output-test url="file://$MODULE_DIR$/../../../httpurlconnection-executor/build/classes/test" />
     <exclude-output />
@@ -22,11 +22,12 @@
     <orderEntry type="module" module-name="http-client-essentials_main" />
     <orderEntry type="module" module-name="http-client-types_main" />
     <orderEntry type="module" module-name="http-client-headers_main" />
+    <orderEntry type="module" module-name="http-client-basics_main" />
+    <orderEntry type="library" name="Gradle: org.mockito:mockito-all:1.9.5" level="project" />
     <orderEntry type="library" name="Gradle: junit:junit:4.11" level="project" />
+    <orderEntry type="module" module-name="http-client-mockutils_main" />
     <orderEntry type="library" name="Gradle: org.dmfs:iterators:1.3" level="project" />
     <orderEntry type="library" name="Gradle: org.hamcrest:hamcrest-core:1.3" level="project" />
-    <orderEntry type="module" module-name="http-client-basics_main" scope="TEST" />
-    <orderEntry type="module" module-name="http-client-mockutils_main" scope="TEST" />
   </component>
   <component name="TestModuleProperties" production-module="httpurlconnection-executor_main" />
 </module>

--- a/httpurlconnection-executor/build.gradle
+++ b/httpurlconnection-executor/build.gradle
@@ -41,4 +41,5 @@ dependencies {
     compile project(':http-client-basics')
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile project(':http-client-mockutils')
+    compile 'org.mockito:mockito-all:1.9.5'
 }

--- a/httpurlconnection-executor/src/main/java/org/dmfs/httpessentials/httpurlconnection/utils/iterators/StringEqualsIgnoreCase.java
+++ b/httpurlconnection-executor/src/main/java/org/dmfs/httpessentials/httpurlconnection/utils/iterators/StringEqualsIgnoreCase.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Marten Gajda <marten@dmfs.org>
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.httpurlconnection.utils.iterators;
+
+import org.dmfs.iterators.AbstractFilteredIterator;
+
+
+/**
+ * An {@link AbstractFilteredIterator.IteratorFilter} that tests for equality in a case agnostic way.
+ *
+ * @author Marten Gajda
+ */
+public final class StringEqualsIgnoreCase implements AbstractFilteredIterator.IteratorFilter<String>
+{
+    private final String mTestValue;
+
+
+    public StringEqualsIgnoreCase(String testValue)
+    {
+        mTestValue = testValue;
+    }
+
+
+    @Override
+    public boolean iterate(String element)
+    {
+        return mTestValue.equalsIgnoreCase(element);
+    }
+}

--- a/httpurlconnection-executor/src/test/java/org/dmfs/httpessentials/httpurlconnection/HttpUrlConnectionHeadersTest.java
+++ b/httpurlconnection-executor/src/test/java/org/dmfs/httpessentials/httpurlconnection/HttpUrlConnectionHeadersTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2016 Marten Gajda <marten@dmfs.org>
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.httpurlconnection;
+
+import org.dmfs.httpessentials.headers.Headers;
+import org.dmfs.httpessentials.headers.HttpHeaders;
+import org.dmfs.httpessentials.types.Link;
+import org.dmfs.httpessentials.types.StructuredMediaType;
+import org.junit.Test;
+
+import java.net.HttpURLConnection;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class HttpUrlConnectionHeadersTest
+{
+    @Test
+    public void testContainsNoHeaders() throws Exception
+    {
+        Map<String, List<String>> headers = new HashMap<>();
+
+        HttpURLConnection connection = mock(HttpURLConnection.class);
+        when(connection.getHeaderFields()).thenReturn(headers);
+
+        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+
+        assertFalse(testHeaders.contains(HttpHeaders.LINK));
+    }
+
+
+    @Test
+    public void testContainsOtherHeaders() throws Exception
+    {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("content-type", Arrays.asList("application/octetstream"));
+
+        HttpURLConnection connection = mock(HttpURLConnection.class);
+        when(connection.getHeaderFields()).thenReturn(headers);
+
+        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+
+        assertFalse(testHeaders.contains(HttpHeaders.LINK));
+    }
+
+
+    @Test
+    public void testContainsMatchingHeaderLowerCase() throws Exception
+    {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("content-type", Arrays.asList("application/octet-stream"));
+        headers.put("link", Arrays.asList("<test5>; rel=\"relation5\",<test6>; rel=\"relation6\"", "<test7>; rel=\"relation7\",<test8>; rel=\"relation8\""));
+
+        HttpURLConnection connection = mock(HttpURLConnection.class);
+        when(connection.getHeaderFields()).thenReturn(headers);
+
+        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+
+        assertTrue(testHeaders.contains(HttpHeaders.LINK));
+    }
+
+
+    @Test
+    public void testContainsMatchingHeaderUpperCase() throws Exception
+    {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("content-type", Arrays.asList("application/octet-stream"));
+        headers.put("LINK", Arrays.asList("<test5>; rel=\"relation5\",<test6>; rel=\"relation6\"", "<test7>; rel=\"relation7\",<test8>; rel=\"relation8\""));
+
+        HttpURLConnection connection = mock(HttpURLConnection.class);
+        when(connection.getHeaderFields()).thenReturn(headers);
+
+        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+
+        assertTrue(testHeaders.contains(HttpHeaders.LINK));
+    }
+
+
+    @Test
+    public void testContainsMatchingHeaderMixedCase() throws Exception
+    {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("content-type", Arrays.asList("application/octet-stream"));
+        headers.put("Link", Arrays.asList("<test5>; rel=\"relation5\",<test6>; rel=\"relation6\"", "<test7>; rel=\"relation7\",<test8>; rel=\"relation8\""));
+
+        HttpURLConnection connection = mock(HttpURLConnection.class);
+        when(connection.getHeaderFields()).thenReturn(headers);
+
+        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+
+        assertTrue(testHeaders.contains(HttpHeaders.LINK));
+    }
+
+
+    @Test
+    public void testContainsMultipleMatchingHeaders() throws Exception
+    {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("content-type", Arrays.asList("application/octet-stream"));
+        headers.put("link", Arrays.asList("<test5>; rel=\"relation5\",<test6>; rel=\"relation6\"", "<test7>; rel=\"relation7\",<test8>; rel=\"relation8\""));
+        headers.put("Link", Arrays.asList("<test1>; rel=\"relation1\",<test2>; rel=\"relation2\"", "<test3>; rel=\"relation3\",<test4>; rel=\"relation4\""));
+
+        HttpURLConnection connection = mock(HttpURLConnection.class);
+        when(connection.getHeaderFields()).thenReturn(headers);
+
+        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+
+        assertTrue(testHeaders.contains(HttpHeaders.LINK));
+    }
+
+
+    @Test
+    public void testSingleHeaderLowerCase() throws Exception
+    {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("content-type", Arrays.asList("application/octetstream"));
+
+        HttpURLConnection connection = mock(HttpURLConnection.class);
+        when(connection.getHeaderFields()).thenReturn(headers);
+
+        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+        assertEquals(new StructuredMediaType("application", "octetstream"), testHeaders.header(HttpHeaders.CONTENT_TYPE).value());
+    }
+
+
+    @Test
+    public void testSingleHeaderUpperCase() throws Exception
+    {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("CONTENT-TYPE", Arrays.asList("application/octetstream"));
+
+        HttpURLConnection connection = mock(HttpURLConnection.class);
+        when(connection.getHeaderFields()).thenReturn(headers);
+
+        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+        assertEquals(new StructuredMediaType("application", "octetstream"), testHeaders.header(HttpHeaders.CONTENT_TYPE).value());
+    }
+
+
+    @Test
+    public void testSingleHeaderMixedCase() throws Exception
+    {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Content-Type", Arrays.asList("application/octetstream"));
+
+        HttpURLConnection connection = mock(HttpURLConnection.class);
+        when(connection.getHeaderFields()).thenReturn(headers);
+
+        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+        assertEquals(new StructuredMediaType("application", "octetstream"), testHeaders.header(HttpHeaders.CONTENT_TYPE).value());
+    }
+
+
+    @Test
+    public void listHeader() throws Exception
+    {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("content-type", Arrays.asList("application/octet-stream"));
+        headers.put("Link", Arrays.asList("<test1>; rel=\"relation1\",<test2>; rel=\"relation2\"", "<test3>; rel=\"relation3\",<test4>; rel=\"relation4\""));
+
+        HttpURLConnection connection = mock(HttpURLConnection.class);
+        when(connection.getHeaderFields()).thenReturn(headers);
+
+        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+
+        List<Link> links = testHeaders.header(HttpHeaders.LINK).value();
+
+        for (int i = 1, count = links.size(); i <= count; ++i)
+        {
+            assertEquals("test" + i, links.get(i - 1).target().toASCIIString());
+        }
+    }
+}


### PR DESCRIPTION
…ive manner. fixes #30

Since we get the headers in a Map of Strings we need to take special case to compate header names case-insensitively.

@lemonboston please review.

I know that there a lot of these annoying iml files in the commit. 