### PR TITLE
Fetch connection headers eagerly to throw an IOException if they are …

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinCommonCompilerArguments">
+    <option name="languageVersion" value="1.1" />
+    <option name="apiVersion" value="1.1" />
+  </component>
+</project>

--- a/.idea/modules/http-client-basics/http-client-basics.iml
+++ b/.idea/modules/http-client-basics/http-client-basics.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-basics" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-basics" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-basics">

--- a/.idea/modules/http-client-basics/http-client-basics_main.iml
+++ b/.idea/modules/http-client-basics/http-client-basics_main.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-basics:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+<module external.linked.project.id=":http-client-basics:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/../../../http-client-basics/build/classes/main" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-basics/src/main">

--- a/.idea/modules/http-client-basics/http-client-basics_test.iml
+++ b/.idea/modules/http-client-basics/http-client-basics_test.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-basics:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+<module external.linked.project.id=":http-client-basics:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output-test url="file://$MODULE_DIR$/../../../http-client-basics/build/classes/test" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-basics/src/test">

--- a/.idea/modules/http-client-essentials-suite.iml
+++ b/.idea/modules/http-client-essentials-suite.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="http-client-essentials-suite" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="http-client-essentials-suite" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../..">

--- a/.idea/modules/http-client-essentials-suite_main.iml
+++ b/.idea/modules/http-client-essentials-suite_main.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="http-client-essentials-suite:main" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+<module external.linked.project.id="http-client-essentials-suite:main" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/../../build/classes/main" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../src/main">

--- a/.idea/modules/http-client-essentials-suite_test.iml
+++ b/.idea/modules/http-client-essentials-suite_test.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="http-client-essentials-suite:test" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+<module external.linked.project.id="http-client-essentials-suite:test" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output-test url="file://$MODULE_DIR$/../../build/classes/test" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../src/test">

--- a/.idea/modules/http-client-essentials/http-client-essentials.iml
+++ b/.idea/modules/http-client-essentials/http-client-essentials.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-essentials" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-essentials" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-essentials">

--- a/.idea/modules/http-client-essentials/http-client-essentials_main.iml
+++ b/.idea/modules/http-client-essentials/http-client-essentials_main.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-essentials:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+<module external.linked.project.id=":http-client-essentials:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/../../../http-client-essentials/build/classes/main" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-essentials/src/main">

--- a/.idea/modules/http-client-essentials/http-client-essentials_test.iml
+++ b/.idea/modules/http-client-essentials/http-client-essentials_test.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-essentials:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+<module external.linked.project.id=":http-client-essentials:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output-test url="file://$MODULE_DIR$/../../../http-client-essentials/build/classes/test" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-essentials/src/test">

--- a/.idea/modules/http-client-headers/http-client-headers.iml
+++ b/.idea/modules/http-client-headers/http-client-headers.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-headers" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-headers" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-headers">

--- a/.idea/modules/http-client-headers/http-client-headers_main.iml
+++ b/.idea/modules/http-client-headers/http-client-headers_main.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-headers:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+<module external.linked.project.id=":http-client-headers:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/../../../http-client-headers/build/classes/main" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-headers/src/main">

--- a/.idea/modules/http-client-headers/http-client-headers_test.iml
+++ b/.idea/modules/http-client-headers/http-client-headers_test.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-headers:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+<module external.linked.project.id=":http-client-headers:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output-test url="file://$MODULE_DIR$/../../../http-client-headers/build/classes/test" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-headers/src/test">

--- a/.idea/modules/http-client-mockutils/http-client-mockutils.iml
+++ b/.idea/modules/http-client-mockutils/http-client-mockutils.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-mockutils" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-mockutils" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-mockutils">

--- a/.idea/modules/http-client-mockutils/http-client-mockutils_main.iml
+++ b/.idea/modules/http-client-mockutils/http-client-mockutils_main.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-mockutils:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+<module external.linked.project.id=":http-client-mockutils:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/../../../http-client-mockutils/build/classes/main" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-mockutils/src/main">

--- a/.idea/modules/http-client-mockutils/http-client-mockutils_test.iml
+++ b/.idea/modules/http-client-mockutils/http-client-mockutils_test.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-mockutils:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+<module external.linked.project.id=":http-client-mockutils:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output-test url="file://$MODULE_DIR$/../../../http-client-mockutils/build/classes/test" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-mockutils/src/test">

--- a/.idea/modules/http-client-types/http-client-types.iml
+++ b/.idea/modules/http-client-types/http-client-types.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-types" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-types" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-types">

--- a/.idea/modules/http-client-types/http-client-types_main.iml
+++ b/.idea/modules/http-client-types/http-client-types_main.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-types:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+<module external.linked.project.id=":http-client-types:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/../../../http-client-types/build/classes/main" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-types/src/main">

--- a/.idea/modules/http-client-types/http-client-types_test.iml
+++ b/.idea/modules/http-client-types/http-client-types_test.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-types:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+<module external.linked.project.id=":http-client-types:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output-test url="file://$MODULE_DIR$/../../../http-client-types/build/classes/test" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-types/src/test">

--- a/.idea/modules/http-executor-decorators/http-executor-decorators.iml
+++ b/.idea/modules/http-executor-decorators/http-executor-decorators.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-executor-decorators" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-executor-decorators" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-executor-decorators">

--- a/.idea/modules/http-executor-decorators/http-executor-decorators_main.iml
+++ b/.idea/modules/http-executor-decorators/http-executor-decorators_main.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-executor-decorators:main" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+<module external.linked.project.id=":http-executor-decorators:main" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/../../../http-executor-decorators/build/classes/main" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-executor-decorators/src/main">

--- a/.idea/modules/http-executor-decorators/http-executor-decorators_test.iml
+++ b/.idea/modules/http-executor-decorators/http-executor-decorators_test.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-executor-decorators:test" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+<module external.linked.project.id=":http-executor-decorators:test" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output-test url="file://$MODULE_DIR$/../../../http-executor-decorators/build/classes/test" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-executor-decorators/src/test">

--- a/.idea/modules/httpurlconnection-executor/httpurlconnection-executor.iml
+++ b/.idea/modules/httpurlconnection-executor/httpurlconnection-executor.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":httpurlconnection-executor" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":httpurlconnection-executor" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../httpurlconnection-executor">

--- a/.idea/modules/httpurlconnection-executor/httpurlconnection-executor_main.iml
+++ b/.idea/modules/httpurlconnection-executor/httpurlconnection-executor_main.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":httpurlconnection-executor:main" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+<module external.linked.project.id=":httpurlconnection-executor:main" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/../../../httpurlconnection-executor/build/classes/main" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../httpurlconnection-executor/build/gen/buildconfig/src/main">
@@ -14,7 +14,6 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="http-client-essentials_main" />
     <orderEntry type="module" module-name="http-client-types_main" />
-    <orderEntry type="module" module-name="http-client-headers_main" />
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
@@ -24,8 +23,8 @@
         <SOURCES />
       </library>
     </orderEntry>
+    <orderEntry type="module" module-name="http-client-headers_main" />
     <orderEntry type="module" module-name="http-client-basics_main" />
-    <orderEntry type="library" name="Gradle: org.mockito:mockito-all:1.9.5" level="project" />
     <orderEntry type="library" name="Gradle: org.dmfs:iterators:1.3" level="project" />
     <orderEntry type="module-library">
       <library>

--- a/.idea/modules/httpurlconnection-executor/httpurlconnection-executor_test.iml
+++ b/.idea/modules/httpurlconnection-executor/httpurlconnection-executor_test.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":httpurlconnection-executor:test" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+<module external.linked.project.id=":httpurlconnection-executor:test" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.2" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output-test url="file://$MODULE_DIR$/../../../httpurlconnection-executor/build/classes/test" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../httpurlconnection-executor/src/test">
@@ -23,9 +23,9 @@
     <orderEntry type="module" module-name="http-client-types_main" />
     <orderEntry type="module" module-name="http-client-headers_main" />
     <orderEntry type="module" module-name="http-client-basics_main" />
-    <orderEntry type="library" name="Gradle: org.mockito:mockito-all:1.9.5" level="project" />
     <orderEntry type="library" name="Gradle: junit:junit:4.11" level="project" />
     <orderEntry type="module" module-name="http-client-mockutils_main" />
+    <orderEntry type="library" name="Gradle: org.mockito:mockito-all:1.9.5" level="project" />
     <orderEntry type="library" name="Gradle: org.dmfs:iterators:1.3" level="project" />
     <orderEntry type="library" name="Gradle: org.hamcrest:hamcrest-core:1.3" level="project" />
   </component>

--- a/httpurlconnection-executor/src/main/java/org/dmfs/httpessentials/httpurlconnection/HttpUrlConnectionResponse.java
+++ b/httpurlconnection-executor/src/main/java/org/dmfs/httpessentials/httpurlconnection/HttpUrlConnectionResponse.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -38,6 +40,7 @@ final class HttpUrlConnectionResponse implements HttpResponse
 {
     private final URI mRequestUri;
     private final HttpURLConnection mConnection;
+    private final Headers mHeaders;
 
 
     /**
@@ -47,10 +50,11 @@ final class HttpUrlConnectionResponse implements HttpResponse
      *         The URL the connection was directed to.
      * @param connection
      */
-    public HttpUrlConnectionResponse(URI resquestUri, HttpURLConnection connection)
+    public HttpUrlConnectionResponse(URI resquestUri, HttpURLConnection connection, Map<String, List<String>> headers)
     {
-        this.mRequestUri = resquestUri;
-        this.mConnection = connection;
+        mRequestUri = resquestUri;
+        mConnection = connection;
+        mHeaders = new HttpUrlConnectionHeaders(headers);
     }
 
 
@@ -71,7 +75,7 @@ final class HttpUrlConnectionResponse implements HttpResponse
     @Override
     public Headers headers()
     {
-        return new HttpUrlConnectionHeaders(mConnection);
+        return mHeaders;
     }
 
 

--- a/httpurlconnection-executor/src/test/java/org/dmfs/httpessentials/httpurlconnection/HttpUrlConnectionHeadersTest.java
+++ b/httpurlconnection-executor/src/test/java/org/dmfs/httpessentials/httpurlconnection/HttpUrlConnectionHeadersTest.java
@@ -23,7 +23,6 @@ import org.dmfs.httpessentials.types.Link;
 import org.dmfs.httpessentials.types.StructuredMediaType;
 import org.junit.Test;
 
-import java.net.HttpURLConnection;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -32,8 +31,6 @@ import java.util.Map;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 
 /**
@@ -46,10 +43,7 @@ public class HttpUrlConnectionHeadersTest
     {
         Map<String, List<String>> headers = new HashMap<>();
 
-        HttpURLConnection connection = mock(HttpURLConnection.class);
-        when(connection.getHeaderFields()).thenReturn(headers);
-
-        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+        Headers testHeaders = new HttpUrlConnectionHeaders(headers);
 
         assertFalse(testHeaders.contains(HttpHeaders.LINK));
     }
@@ -61,10 +55,7 @@ public class HttpUrlConnectionHeadersTest
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("content-type", Arrays.asList("application/octetstream"));
 
-        HttpURLConnection connection = mock(HttpURLConnection.class);
-        when(connection.getHeaderFields()).thenReturn(headers);
-
-        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+        Headers testHeaders = new HttpUrlConnectionHeaders(headers);
 
         assertFalse(testHeaders.contains(HttpHeaders.LINK));
     }
@@ -77,10 +68,7 @@ public class HttpUrlConnectionHeadersTest
         headers.put("content-type", Arrays.asList("application/octet-stream"));
         headers.put("link", Arrays.asList("<test5>; rel=\"relation5\",<test6>; rel=\"relation6\"", "<test7>; rel=\"relation7\",<test8>; rel=\"relation8\""));
 
-        HttpURLConnection connection = mock(HttpURLConnection.class);
-        when(connection.getHeaderFields()).thenReturn(headers);
-
-        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+        Headers testHeaders = new HttpUrlConnectionHeaders(headers);
 
         assertTrue(testHeaders.contains(HttpHeaders.LINK));
     }
@@ -93,10 +81,7 @@ public class HttpUrlConnectionHeadersTest
         headers.put("content-type", Arrays.asList("application/octet-stream"));
         headers.put("LINK", Arrays.asList("<test5>; rel=\"relation5\",<test6>; rel=\"relation6\"", "<test7>; rel=\"relation7\",<test8>; rel=\"relation8\""));
 
-        HttpURLConnection connection = mock(HttpURLConnection.class);
-        when(connection.getHeaderFields()).thenReturn(headers);
-
-        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+        Headers testHeaders = new HttpUrlConnectionHeaders(headers);
 
         assertTrue(testHeaders.contains(HttpHeaders.LINK));
     }
@@ -109,10 +94,7 @@ public class HttpUrlConnectionHeadersTest
         headers.put("content-type", Arrays.asList("application/octet-stream"));
         headers.put("Link", Arrays.asList("<test5>; rel=\"relation5\",<test6>; rel=\"relation6\"", "<test7>; rel=\"relation7\",<test8>; rel=\"relation8\""));
 
-        HttpURLConnection connection = mock(HttpURLConnection.class);
-        when(connection.getHeaderFields()).thenReturn(headers);
-
-        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+        Headers testHeaders = new HttpUrlConnectionHeaders(headers);
 
         assertTrue(testHeaders.contains(HttpHeaders.LINK));
     }
@@ -126,10 +108,7 @@ public class HttpUrlConnectionHeadersTest
         headers.put("link", Arrays.asList("<test5>; rel=\"relation5\",<test6>; rel=\"relation6\"", "<test7>; rel=\"relation7\",<test8>; rel=\"relation8\""));
         headers.put("Link", Arrays.asList("<test1>; rel=\"relation1\",<test2>; rel=\"relation2\"", "<test3>; rel=\"relation3\",<test4>; rel=\"relation4\""));
 
-        HttpURLConnection connection = mock(HttpURLConnection.class);
-        when(connection.getHeaderFields()).thenReturn(headers);
-
-        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+        Headers testHeaders = new HttpUrlConnectionHeaders(headers);
 
         assertTrue(testHeaders.contains(HttpHeaders.LINK));
     }
@@ -141,10 +120,7 @@ public class HttpUrlConnectionHeadersTest
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("content-type", Arrays.asList("application/octetstream"));
 
-        HttpURLConnection connection = mock(HttpURLConnection.class);
-        when(connection.getHeaderFields()).thenReturn(headers);
-
-        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+        Headers testHeaders = new HttpUrlConnectionHeaders(headers);
         assertEquals(new StructuredMediaType("application", "octetstream"), testHeaders.header(HttpHeaders.CONTENT_TYPE).value());
     }
 
@@ -155,10 +131,7 @@ public class HttpUrlConnectionHeadersTest
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("CONTENT-TYPE", Arrays.asList("application/octetstream"));
 
-        HttpURLConnection connection = mock(HttpURLConnection.class);
-        when(connection.getHeaderFields()).thenReturn(headers);
-
-        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+        Headers testHeaders = new HttpUrlConnectionHeaders(headers);
         assertEquals(new StructuredMediaType("application", "octetstream"), testHeaders.header(HttpHeaders.CONTENT_TYPE).value());
     }
 
@@ -169,10 +142,7 @@ public class HttpUrlConnectionHeadersTest
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("Content-Type", Arrays.asList("application/octetstream"));
 
-        HttpURLConnection connection = mock(HttpURLConnection.class);
-        when(connection.getHeaderFields()).thenReturn(headers);
-
-        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+        Headers testHeaders = new HttpUrlConnectionHeaders(headers);
         assertEquals(new StructuredMediaType("application", "octetstream"), testHeaders.header(HttpHeaders.CONTENT_TYPE).value());
     }
 
@@ -184,10 +154,7 @@ public class HttpUrlConnectionHeadersTest
         headers.put("content-type", Arrays.asList("application/octet-stream"));
         headers.put("Link", Arrays.asList("<test1>; rel=\"relation1\",<test2>; rel=\"relation2\"", "<test3>; rel=\"relation3\",<test4>; rel=\"relation4\""));
 
-        HttpURLConnection connection = mock(HttpURLConnection.class);
-        when(connection.getHeaderFields()).thenReturn(headers);
-
-        Headers testHeaders = new HttpUrlConnectionHeaders(connection);
+        Headers testHeaders = new HttpUrlConnectionHeaders(headers);
 
         List<Link> links = testHeaders.header(HttpHeaders.LINK).value();
 


### PR DESCRIPTION
…null. Apparently URLConnection.getHeaderFields() may return null instead of throwing an IOException if it can't retrive the headers.

Fixes #39