### PR TITLE
Add UrlRewriting decorator that can be used to rewrite requests to pe…

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,26 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <resourceExtensions />
-    <wildcardResourcePatterns>
-      <entry name="!?*.java" />
-      <entry name="!?*.form" />
-      <entry name="!?*.class" />
-      <entry name="!?*.groovy" />
-      <entry name="!?*.scala" />
-      <entry name="!?*.flex" />
-      <entry name="!?*.kt" />
-      <entry name="!?*.clj" />
-      <entry name="!?*.aj" />
-    </wildcardResourcePatterns>
-    <annotationProcessing>
-      <profile default="true" name="Default" enabled="false">
-        <processorPath useClasspath="true" />
-      </profile>
-    </annotationProcessing>
     <bytecodeTargetLevel>
       <module name="http-client-basics_main" target="1.7" />
       <module name="http-client-basics_test" target="1.7" />
+      <module name="http-client-essentials-suite-http-client-basics_main" target="1.7" />
+      <module name="http-client-essentials-suite-http-client-basics_test" target="1.7" />
+      <module name="http-client-essentials-suite-http-client-essentials_main" target="1.7" />
+      <module name="http-client-essentials-suite-http-client-essentials_test" target="1.7" />
+      <module name="http-client-essentials-suite-http-client-headers_main" target="1.7" />
+      <module name="http-client-essentials-suite-http-client-headers_test" target="1.7" />
+      <module name="http-client-essentials-suite-http-client-mockutils_main" target="1.7" />
+      <module name="http-client-essentials-suite-http-client-mockutils_test" target="1.7" />
+      <module name="http-client-essentials-suite-http-client-types_main" target="1.7" />
+      <module name="http-client-essentials-suite-http-client-types_test" target="1.7" />
+      <module name="http-client-essentials-suite-http-executor-decorators_main" target="1.7" />
+      <module name="http-client-essentials-suite-http-executor-decorators_test" target="1.7" />
+      <module name="http-client-essentials-suite-httpurlconnection-executor_main" target="1.7" />
+      <module name="http-client-essentials-suite-httpurlconnection-executor_test" target="1.7" />
       <module name="http-client-essentials-suite_main" target="1.7" />
       <module name="http-client-essentials-suite_test" target="1.7" />
       <module name="http-client-essentials_main" target="1.7" />
@@ -35,6 +32,8 @@
       <module name="http-executor-decorators_test" target="1.7" />
       <module name="httpurlconnection-executor_main" target="1.7" />
       <module name="httpurlconnection-executor_test" target="1.7" />
+      <module name="workspace-http-client-essentials-suite_main" target="1.7" />
+      <module name="workspace-http-client-essentials-suite_test" target="1.7" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/modules/http-client-basics/http-client-basics.iml
+++ b/.idea/modules/http-client-basics/http-client-basics.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-basics" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-basics" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-basics">

--- a/.idea/modules/http-client-basics/http-client-basics_main.iml
+++ b/.idea/modules/http-client-basics/http-client-basics_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-basics:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-basics:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/../../../http-client-basics/build/classes/main" />
     <exclude-output />

--- a/.idea/modules/http-client-basics/http-client-basics_test.iml
+++ b/.idea/modules/http-client-basics/http-client-basics_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-basics:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-basics:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-basics" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output-test url="file://$MODULE_DIR$/../../../http-client-basics/build/classes/test" />
     <exclude-output />

--- a/.idea/modules/http-client-essentials-suite.iml
+++ b/.idea/modules/http-client-essentials-suite.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="http-client-essentials-suite" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="http-client-essentials-suite" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../..">

--- a/.idea/modules/http-client-essentials-suite_main.iml
+++ b/.idea/modules/http-client-essentials-suite_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="http-client-essentials-suite:main" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="http-client-essentials-suite:main" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/../../build/classes/main" />
     <exclude-output />

--- a/.idea/modules/http-client-essentials-suite_test.iml
+++ b/.idea/modules/http-client-essentials-suite_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="http-client-essentials-suite:test" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="http-client-essentials-suite:test" external.linked.project.path="$MODULE_DIR$/../.." external.root.project.path="$MODULE_DIR$/../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output-test url="file://$MODULE_DIR$/../../build/classes/test" />
     <exclude-output />

--- a/.idea/modules/http-client-essentials/http-client-essentials.iml
+++ b/.idea/modules/http-client-essentials/http-client-essentials.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-essentials" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-essentials" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-essentials">

--- a/.idea/modules/http-client-essentials/http-client-essentials_main.iml
+++ b/.idea/modules/http-client-essentials/http-client-essentials_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-essentials:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-essentials:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/../../../http-client-essentials/build/classes/main" />
     <exclude-output />

--- a/.idea/modules/http-client-essentials/http-client-essentials_test.iml
+++ b/.idea/modules/http-client-essentials/http-client-essentials_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-essentials:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-essentials:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-essentials" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output-test url="file://$MODULE_DIR$/../../../http-client-essentials/build/classes/test" />
     <exclude-output />

--- a/.idea/modules/http-client-headers/http-client-headers.iml
+++ b/.idea/modules/http-client-headers/http-client-headers.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-headers" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-headers" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-headers">

--- a/.idea/modules/http-client-headers/http-client-headers_main.iml
+++ b/.idea/modules/http-client-headers/http-client-headers_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-headers:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-headers:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/../../../http-client-headers/build/classes/main" />
     <exclude-output />

--- a/.idea/modules/http-client-headers/http-client-headers_test.iml
+++ b/.idea/modules/http-client-headers/http-client-headers_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-headers:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-headers:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-headers" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output-test url="file://$MODULE_DIR$/../../../http-client-headers/build/classes/test" />
     <exclude-output />

--- a/.idea/modules/http-client-mockutils/http-client-mockutils.iml
+++ b/.idea/modules/http-client-mockutils/http-client-mockutils.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-mockutils" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-mockutils" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-mockutils">

--- a/.idea/modules/http-client-mockutils/http-client-mockutils_main.iml
+++ b/.idea/modules/http-client-mockutils/http-client-mockutils_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-mockutils:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-mockutils:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/../../../http-client-mockutils/build/classes/main" />
     <exclude-output />

--- a/.idea/modules/http-client-mockutils/http-client-mockutils_test.iml
+++ b/.idea/modules/http-client-mockutils/http-client-mockutils_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-mockutils:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-mockutils:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-mockutils" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output-test url="file://$MODULE_DIR$/../../../http-client-mockutils/build/classes/test" />
     <exclude-output />

--- a/.idea/modules/http-client-types/http-client-types.iml
+++ b/.idea/modules/http-client-types/http-client-types.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-types" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-types" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-client-types">

--- a/.idea/modules/http-client-types/http-client-types_main.iml
+++ b/.idea/modules/http-client-types/http-client-types_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-types:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-types:main" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/../../../http-client-types/build/classes/main" />
     <exclude-output />

--- a/.idea/modules/http-client-types/http-client-types_test.iml
+++ b/.idea/modules/http-client-types/http-client-types_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-client-types:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-client-types:test" external.linked.project.path="$MODULE_DIR$/../../../http-client-types" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output-test url="file://$MODULE_DIR$/../../../http-client-types/build/classes/test" />
     <exclude-output />

--- a/.idea/modules/http-executor-decorators/http-executor-decorators.iml
+++ b/.idea/modules/http-executor-decorators/http-executor-decorators.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-executor-decorators" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-executor-decorators" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../http-executor-decorators">

--- a/.idea/modules/http-executor-decorators/http-executor-decorators_main.iml
+++ b/.idea/modules/http-executor-decorators/http-executor-decorators_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-executor-decorators:main" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-executor-decorators:main" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/../../../http-executor-decorators/build/classes/main" />
     <exclude-output />

--- a/.idea/modules/http-executor-decorators/http-executor-decorators_test.iml
+++ b/.idea/modules/http-executor-decorators/http-executor-decorators_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":http-executor-decorators:test" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":http-executor-decorators:test" external.linked.project.path="$MODULE_DIR$/../../../http-executor-decorators" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output-test url="file://$MODULE_DIR$/../../../http-executor-decorators/build/classes/test" />
     <exclude-output />
@@ -17,7 +17,6 @@
     <orderEntry type="library" name="Gradle: junit:junit:4.11" level="project" />
     <orderEntry type="library" name="Gradle: org.jmockit:jmockit:1.26" level="project" />
     <orderEntry type="module" module-name="http-client-mockutils_main" />
-    <orderEntry type="library" name="Gradle: org.mockito:mockito-all:1.9.5" level="project" />
     <orderEntry type="library" name="Gradle: org.dmfs:iterators:1.3" level="project" />
     <orderEntry type="library" name="Gradle: org.hamcrest:hamcrest-core:1.3" level="project" />
   </component>

--- a/.idea/modules/httpurlconnection-executor/httpurlconnection-executor.iml
+++ b/.idea/modules/httpurlconnection-executor/httpurlconnection-executor.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":httpurlconnection-executor" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":httpurlconnection-executor" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../httpurlconnection-executor">

--- a/.idea/modules/httpurlconnection-executor/httpurlconnection-executor_main.iml
+++ b/.idea/modules/httpurlconnection-executor/httpurlconnection-executor_main.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":httpurlconnection-executor:main" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":httpurlconnection-executor:main" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/../../../httpurlconnection-executor/build/classes/main" />
     <exclude-output />

--- a/.idea/modules/httpurlconnection-executor/httpurlconnection-executor_test.iml
+++ b/.idea/modules/httpurlconnection-executor/httpurlconnection-executor_test.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":httpurlconnection-executor:test" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":httpurlconnection-executor:test" external.linked.project.path="$MODULE_DIR$/../../../httpurlconnection-executor" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="GRADLE" external.system.module.group="org.dmfs" external.system.module.type="sourceSet" external.system.module.version="0.10.3-3-gf1aba3a" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output-test url="file://$MODULE_DIR$/../../../httpurlconnection-executor/build/classes/test" />
     <exclude-output />

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/urlrewriting/RewritePolicy.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/urlrewriting/RewritePolicy.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.urlrewriting;
+
+import java.net.URI;
+
+
+/**
+ * A policy for request URL rewrites. A {@link RewritePolicy} knows how to modify the URL of a request.
+ *
+ * @author Marten Gajda
+ */
+public interface RewritePolicy
+{
+    /**
+     * Returns the new URI for any given {@link URI}. If the URL is not supposed to be rewritten this has to return the original {@link URI}.
+     *
+     * @param location
+     *         The original request location.
+     *
+     * @return The actual request location.
+     */
+    URI rewritten(URI location);
+}

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/urlrewriting/UrlRewriting.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/urlrewriting/UrlRewriting.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.urlrewriting;
+
+import org.dmfs.httpessentials.client.HttpRequest;
+import org.dmfs.httpessentials.client.HttpRequestExecutor;
+import org.dmfs.httpessentials.exceptions.ProtocolError;
+import org.dmfs.httpessentials.exceptions.ProtocolException;
+import org.dmfs.httpessentials.exceptions.RedirectionException;
+import org.dmfs.httpessentials.exceptions.UnexpectedStatusException;
+
+import java.io.IOException;
+import java.net.URI;
+
+
+/**
+ * An {@link HttpRequestExecutor} decorator that rewrites requested URLs as per the given {@link RewritePolicy}.
+ *
+ * @author Marten Gajda
+ */
+public final class UrlRewriting implements HttpRequestExecutor
+{
+    private final HttpRequestExecutor mDelegate;
+    private final RewritePolicy mRewritePolicy;
+
+
+    /**
+     * Creates an {@link HttpRequestExecutor} that rewrites request URLs.
+     *
+     * @param delegate
+     *         The decorated {@link HttpRequestExecutor}.
+     * @param rewritePolicy
+     *         A {@link RewritePolicy} that determines how URLs have to be rewritten.
+     */
+    public UrlRewriting(HttpRequestExecutor delegate, RewritePolicy rewritePolicy)
+    {
+        mDelegate = delegate;
+        mRewritePolicy = rewritePolicy;
+    }
+
+
+    @Override
+    public <T> T execute(URI uri, HttpRequest<T> request) throws IOException, ProtocolError, ProtocolException, RedirectionException, UnexpectedStatusException
+    {
+        return mDelegate.execute(mRewritePolicy.rewritten(uri), request);
+    }
+}


### PR DESCRIPTION
…rmanently redirected targets. #12

It takes a RewritePolicy that determines the actual target of a request. This is could also be used to add a default request parameter or to replace http by https on every request.

This also adds a RedirectPolicy which stores all permanent redirects. It can be used in conjunction with SimpleRewritePolicy which reads redirects from the same source.