### PR TITLE
Rename RedirectPolicy to RedirectStrategy. Implements #81

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,6 @@ POM_SCM_CONNECTION=scm:git:git@github.com:dmfs/http-client-essentials-suite.git
 POM_SCM_DEVELOPER_CONNECTION=scm:git:git@github.com:dmfs/http-client-essentials-suite.git
 # dependency versions
 JUNIT_VERSION=4.12
-JEMS_VERSION=1.23
+JEMS_VERSION=1.40
 HAMCREST_VERSION=1.3
 MOCKITO_VERSION=3.0.0

--- a/http-client-mockutils/src/main/java/org/dmfs/httpessentials/mockutils/entities/StaticMockResponseEntity.java
+++ b/http-client-mockutils/src/main/java/org/dmfs/httpessentials/mockutils/entities/StaticMockResponseEntity.java
@@ -20,6 +20,7 @@ package org.dmfs.httpessentials.mockutils.entities;
 import org.dmfs.httpessentials.client.HttpResponseEntity;
 import org.dmfs.httpessentials.types.MediaType;
 import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Absent;
 import org.dmfs.jems.optional.elementary.Present;
 
 import java.io.ByteArrayInputStream;
@@ -37,6 +38,12 @@ public final class StaticMockResponseEntity implements HttpResponseEntity
     private final Optional<MediaType> mContentType;
     private final Optional<Long> mContentLength;
     private final byte[] mContent;
+
+
+    public StaticMockResponseEntity()
+    {
+        this(new Absent<>(), new Absent<>(), new byte[0]);
+    }
 
 
     /**

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/RedirectPolicy.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/RedirectPolicy.java
@@ -31,6 +31,7 @@ import java.net.URI;
  * @author Marten Gajda
  * @author Gabor Keszthelyi
  */
+@Deprecated
 public interface RedirectPolicy
 {
 

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/RedirectStrategy.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/RedirectStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following;
+
+import org.dmfs.httpessentials.client.HttpResponse;
+import org.dmfs.jems.optional.Optional;
+
+import java.net.URI;
+
+
+/**
+ * A strategy to decide what to do with a redirect response: follow it or not and to what new location. Receiving the entire response allows specifically
+ * customized policy implementations.
+ */
+public interface RedirectStrategy
+{
+    /***
+     * Called when a redirect response is received. Returns the {@link Optional} URI to follow or an absent value to not follow the redirect.
+     *
+     * @param response
+     *         The response which may have to be redirected.
+     * @param redirectNumber
+     *         the number of this redirect in the call
+     */
+    Optional<URI> location(HttpResponse response, int redirectNumber);
+
+}

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/policies/Composite.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/policies/Composite.java
@@ -32,6 +32,7 @@ import java.net.URI;
  *
  * @author Marten Gajda
  */
+@Deprecated
 public final class Composite implements RedirectPolicy
 {
     private final Iterable<RedirectPolicy> mDelegates;

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/policies/FollowPolicy.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/policies/FollowPolicy.java
@@ -37,6 +37,7 @@ import static org.dmfs.httpessentials.HttpStatus.TEMPORARY_REDIRECT;
  *
  * @author Marten Gajda
  */
+@Deprecated
 public final class FollowPolicy implements RedirectPolicy
 {
     @Override

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/policies/FollowRedirectPolicy.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/policies/FollowRedirectPolicy.java
@@ -38,6 +38,7 @@ import static org.dmfs.httpessentials.HttpStatus.TEMPORARY_REDIRECT;
  *
  * @author Gabor Keszthelyi
  */
+@Deprecated
 public final class FollowRedirectPolicy implements RedirectPolicy
 {
     /**

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/policies/Limited.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/policies/Limited.java
@@ -30,6 +30,7 @@ import java.net.URI;
  *
  * @author Marten Gajda
  */
+@Deprecated
 public final class Limited implements RedirectPolicy
 {
     /**

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/policies/NeverFollowRedirectPolicy.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/policies/NeverFollowRedirectPolicy.java
@@ -37,6 +37,7 @@ import static org.dmfs.httpessentials.HttpStatus.TEMPORARY_REDIRECT;
  *
  * @author Gabor Keszthelyi
  */
+@Deprecated
 public final class NeverFollowRedirectPolicy implements RedirectPolicy
 {
 

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/policies/Relative.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/policies/Relative.java
@@ -30,6 +30,7 @@ import java.net.URI;
  *
  * @author Marten Gajda
  */
+@Deprecated
 public final class Relative implements RedirectPolicy
 {
     private final RedirectPolicy mDelegate;

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/policies/Secure.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/policies/Secure.java
@@ -31,6 +31,7 @@ import java.net.URI;
  *
  * @author Gabor Keszthelyi
  */
+@Deprecated
 public final class Secure implements RedirectPolicy
 {
 

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/policies/Temporary.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/policies/Temporary.java
@@ -41,6 +41,7 @@ import static org.dmfs.httpessentials.HttpStatus.TEMPORARY_REDIRECT;
  *
  * @author Marten Gajda
  */
+@Deprecated
 public final class Temporary implements RedirectPolicy
 {
     private final RedirectPolicy mDecoratedPolicy;

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/Bool.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/Bool.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies;
+
+import org.dmfs.jems.predicate.Predicate;
+import org.dmfs.jems.single.Single;
+import org.dmfs.jems.single.decorators.DelegatingSingle;
+import org.dmfs.jems.single.elementary.ValueSingle;
+
+
+/**
+ * A {@link Single} {@link Boolean} derived from other values.
+ *
+ * @deprecated consider moving this into jems.
+ */
+@Deprecated
+final class Bool extends DelegatingSingle<Boolean>
+{
+    <T> Bool(T value, Predicate<? super T> predicate)
+    {
+        this(new ValueSingle<>(value), predicate);
+    }
+
+
+    <T> Bool(Single<? extends T> value, Predicate<? super T> predicate)
+    {
+        super(() -> predicate.satisfiedBy(value.value()));
+    }
+}

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/Composite.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/Composite.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies;
+
+import org.dmfs.httpessentials.executors.following.RedirectStrategy;
+import org.dmfs.jems.iterable.decorators.Mapped;
+import org.dmfs.jems.iterable.elementary.Seq;
+import org.dmfs.jems.optional.adapters.FirstPresent;
+
+
+/**
+ * A {@link RedirectStrategy} which follows the first {@link RedirectStrategy} which returns a result.
+ */
+public final class Composite extends DelegatingRedirectStrategy
+{
+    public Composite(RedirectStrategy... delegates)
+    {
+        this(new Seq<>(delegates));
+    }
+
+
+    public Composite(Iterable<? extends RedirectStrategy> delegates)
+    {
+        super(((response, redirectNumber) ->
+                new FirstPresent<>(
+                        new Mapped<>(
+                                strategy -> strategy.location(response, redirectNumber),
+                                delegates))));
+    }
+}

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/DelegatingRedirectStrategy.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/DelegatingRedirectStrategy.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies;
+
+import org.dmfs.httpessentials.client.HttpResponse;
+import org.dmfs.httpessentials.executors.following.RedirectStrategy;
+import org.dmfs.jems.optional.Optional;
+
+import java.net.URI;
+
+
+/**
+ * A {@link RedirectStrategy} to delegate to another {@link RedirectStrategy}.
+ */
+public abstract class DelegatingRedirectStrategy implements RedirectStrategy
+{
+    private final RedirectStrategy mDelegate;
+
+
+    public DelegatingRedirectStrategy(RedirectStrategy delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public final Optional<URI> location(HttpResponse response, int redirectNumber)
+    {
+        return mDelegate.location(response, redirectNumber);
+    }
+}

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/FollowStrategy.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/FollowStrategy.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies;
+
+import org.dmfs.httpessentials.client.HttpResponse;
+import org.dmfs.httpessentials.executors.following.RedirectStrategy;
+import org.dmfs.httpessentials.headers.HttpHeaders;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.adapters.Conditional;
+import org.dmfs.jems.optional.decorators.Mapped;
+import org.dmfs.jems.predicate.composite.AnyOf;
+import org.dmfs.jems.predicate.composite.Having;
+
+import java.net.URI;
+
+import static org.dmfs.httpessentials.HttpStatus.FOUND;
+import static org.dmfs.httpessentials.HttpStatus.MOVED_PERMANENTLY;
+import static org.dmfs.httpessentials.HttpStatus.PERMANENT_REDIRECT;
+import static org.dmfs.httpessentials.HttpStatus.TEMPORARY_REDIRECT;
+
+
+/**
+ * A {@link RedirectStrategy} that follows all temporary and permanent redirects.
+ */
+public final class FollowStrategy implements RedirectStrategy
+{
+    @Override
+    public Optional<URI> location(HttpResponse response, int redirectNumber)
+    {
+        return new Mapped<>(
+                r -> r.responseUri().resolve(r.headers().header(HttpHeaders.LOCATION).value()),
+                new Conditional<>(
+                        new Having<>(HttpResponse::status, new AnyOf<>(MOVED_PERMANENTLY, FOUND, TEMPORARY_REDIRECT, PERMANENT_REDIRECT)),
+                        response));
+    }
+}

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/Limited.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/Limited.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies;
+
+import org.dmfs.httpessentials.client.HttpResponse;
+import org.dmfs.httpessentials.executors.following.RedirectStrategy;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.decorators.Restrained;
+
+import java.net.URI;
+
+
+/**
+ * A {@link RedirectStrategy} which restricts the number of redirects it follows.
+ */
+public final class Limited implements RedirectStrategy
+{
+    /**
+     * The default maximum redirects per request.
+     */
+    private static final int DEFAULT_MAX_REDIRECTS = 5;
+
+    private final int mMaxNumberOfRedirects;
+    private final RedirectStrategy mDelegate;
+
+
+    /**
+     * Creates a {@link Limited} {@link RedirectStrategy} with the default redirect limit of {@value DEFAULT_MAX_REDIRECTS}.
+     */
+    public Limited(RedirectStrategy delegate)
+    {
+        this(DEFAULT_MAX_REDIRECTS, delegate);
+    }
+
+
+    public Limited(int maxNumberOfRedirects, RedirectStrategy delegate)
+    {
+        mMaxNumberOfRedirects = maxNumberOfRedirects;
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public Optional<URI> location(HttpResponse response, int redirectNumber)
+    {
+        return new Restrained<>(
+                () -> redirectNumber <= mMaxNumberOfRedirects,
+                mDelegate.location(response, redirectNumber));
+    }
+}

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/NeverFollowStrategy.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/NeverFollowStrategy.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies;
+
+import org.dmfs.httpessentials.client.HttpResponse;
+import org.dmfs.httpessentials.executors.following.RedirectStrategy;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Absent;
+
+import java.net.URI;
+
+
+/**
+ * A {@link RedirectStrategy} that never follows redirects.
+ */
+public final class NeverFollowStrategy implements RedirectStrategy
+{
+    @Override
+    public Optional<URI> location(HttpResponse response, int redirectNumber)
+    {
+        return new Absent<>();
+    }
+}

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/Permanent.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/Permanent.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies;
+
+import org.dmfs.httpessentials.client.HttpResponse;
+import org.dmfs.httpessentials.executors.following.RedirectStrategy;
+import org.dmfs.jems.optional.decorators.Restrained;
+import org.dmfs.jems.predicate.composite.AnyOf;
+import org.dmfs.jems.predicate.composite.Having;
+
+import static org.dmfs.httpessentials.HttpStatus.MOVED_PERMANENTLY;
+import static org.dmfs.httpessentials.HttpStatus.PERMANENT_REDIRECT;
+
+
+/**
+ * A {@link RedirectStrategy} to follow permanent redirects only. Temporary redirects will not be handled with this strategy in charge and the request will be
+ * forwarded to the next instance.
+ * <p>
+ * Example use case:
+ * <pre>{@code
+ * // follows permanent and secure redirects
+ * new Following(executor, new Permanent(new Secure(new FollowStrategy())));
+ * }</pre>
+ */
+public final class Permanent extends DelegatingRedirectStrategy
+{
+    public Permanent(RedirectStrategy delegate)
+    {
+        super((response, redirectNumber) ->
+                new Restrained<>(
+                        new Bool(response, new Having<>(HttpResponse::status, new AnyOf<>(MOVED_PERMANENTLY, PERMANENT_REDIRECT))),
+                        delegate.location(response, redirectNumber)));
+    }
+
+}

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/SameAuthority.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/SameAuthority.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies;
+
+import org.dmfs.httpessentials.client.HttpResponse;
+import org.dmfs.httpessentials.executors.following.RedirectStrategy;
+import org.dmfs.jems.optional.decorators.Sieved;
+import org.dmfs.jems.predicate.Predicate;
+import org.dmfs.jems.predicate.composite.AllOf;
+import org.dmfs.jems.predicate.composite.Having;
+import org.dmfs.jems.predicate.elementary.Equals;
+
+import java.net.URI;
+
+
+/**
+ * A {@link RedirectStrategy} decorator that only follows redirects to the same host and the same scheme.
+ */
+public final class SameAuthority extends DelegatingRedirectStrategy
+{
+    public SameAuthority(RedirectStrategy delegate)
+    {
+        super(((response, redirectNumber) ->
+                new Sieved<>(
+                        sameHost(response),
+                        delegate.location(response, redirectNumber))));
+    }
+
+
+    private static Predicate<URI> sameHost(HttpResponse response)
+    {
+        return new AllOf<>(
+                new Having<>(URI::getScheme, new Equals<>(response.responseUri().getScheme())),
+                new Having<>(URI::getAuthority, new Equals<>(response.responseUri().getAuthority())));
+
+    }
+}

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/Secure.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/Secure.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies;
+
+import org.dmfs.httpessentials.client.HttpResponse;
+import org.dmfs.httpessentials.executors.following.RedirectStrategy;
+import org.dmfs.jems.optional.decorators.Restrained;
+import org.dmfs.jems.optional.decorators.Sieved;
+import org.dmfs.jems.predicate.Predicate;
+import org.dmfs.jems.predicate.composite.Having;
+
+import java.net.URI;
+
+
+/**
+ * A {@link RedirectStrategy} that only follows redirects from and to secure addresses. (Source and destination both need to be https urls.)
+ */
+public final class Secure extends DelegatingRedirectStrategy
+{
+    private static final Predicate<URI> IS_HTTPS_SCHEME = new Having<>(URI::getScheme, "https"::equalsIgnoreCase);
+
+
+    public Secure(RedirectStrategy delegate)
+    {
+        super(((response, redirectNumber) ->
+                new Restrained<>(
+                        new Bool(response, new Having<>(HttpResponse::responseUri, IS_HTTPS_SCHEME)),
+                        new Sieved<>(IS_HTTPS_SCHEME, delegate.location(response, redirectNumber)))));
+    }
+}

--- a/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/Temporary.java
+++ b/http-executor-decorators/src/main/java/org/dmfs/httpessentials/executors/following/strategies/Temporary.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies;
+
+import org.dmfs.httpessentials.client.HttpResponse;
+import org.dmfs.httpessentials.executors.following.RedirectStrategy;
+import org.dmfs.jems.optional.decorators.Restrained;
+import org.dmfs.jems.predicate.composite.AnyOf;
+import org.dmfs.jems.predicate.composite.Having;
+
+import static org.dmfs.httpessentials.HttpStatus.FOUND;
+import static org.dmfs.httpessentials.HttpStatus.TEMPORARY_REDIRECT;
+
+
+/**
+ * A {@link RedirectStrategy} to follow temporary redirects only. Permanent redirects will not be handled with this policy in charge and the request will be
+ * forwarded to the next instance.
+ * <p>
+ * Example use case:
+ * <pre>{@code
+ * // follows temporary and secure redirects
+ * new Following(executor, new Temporary(new Secure(new FollowStrategy())));
+ * }</pre>
+ */
+public final class Temporary extends DelegatingRedirectStrategy
+{
+    public Temporary(RedirectStrategy delegate)
+    {
+        super((response, redirectNumber) ->
+                new Restrained<>(
+                        new Bool(response, new Having<>(HttpResponse::status, new AnyOf<>(FOUND, TEMPORARY_REDIRECT))),
+                        delegate.location(response, redirectNumber)));
+    }
+}

--- a/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/FollowingTest.java
+++ b/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/FollowingTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following;
+
+import org.dmfs.httpessentials.HttpMethod;
+import org.dmfs.httpessentials.client.HttpRequest;
+import org.dmfs.httpessentials.client.HttpRequestEntity;
+import org.dmfs.httpessentials.client.HttpRequestExecutor;
+import org.dmfs.httpessentials.client.HttpResponse;
+import org.dmfs.httpessentials.client.HttpResponseHandler;
+import org.dmfs.httpessentials.entities.EmptyHttpRequestEntity;
+import org.dmfs.httpessentials.exceptions.UnexpectedStatusException;
+import org.dmfs.httpessentials.executors.following.strategies.FollowStrategy;
+import org.dmfs.httpessentials.executors.following.strategies.Limited;
+import org.dmfs.httpessentials.headers.EmptyHeaders;
+import org.dmfs.httpessentials.headers.Headers;
+import org.dmfs.httpessentials.httpurlconnection.HttpUrlConnectionExecutor;
+import org.dmfs.httpessentials.responsehandlers.FailResponseHandler;
+import org.dmfs.httpessentials.responsehandlers.StringResponseHandler;
+import org.junit.Test;
+
+import java.net.URI;
+
+
+/**
+ * Unit test for {@link Following}.
+ *
+ * @author marten
+ */
+public class FollowingTest
+{
+
+
+    @Test
+    public void testDirect() throws Exception
+    {
+        HttpRequestExecutor executor = new Following(new FollowStrategy(), new HttpUrlConnectionExecutor());
+
+        String response = executor.execute(URI.create("http://localhost:5000/get"), new StringHttpRequest());
+
+        System.out.println(response);
+    }
+
+
+
+    @Test
+    public void testExecuteAbsolute4() throws Exception
+    {
+        HttpRequestExecutor executor = new Following(new FollowStrategy(), new HttpUrlConnectionExecutor());
+
+        String response = executor.execute(URI.create("http://localhost:5000/absolute-redirect/4"), new StringHttpRequest());
+
+        System.out.println(response);
+    }
+
+
+    @Test
+    public void testExecuteRelative4() throws Exception
+    {
+        HttpRequestExecutor executor = new Following(new FollowStrategy(), new HttpUrlConnectionExecutor());
+
+        String response = executor.execute(URI.create("http://localhost:5000/relative-redirect/4"), new StringHttpRequest());
+
+        System.out.println(response);
+    }
+
+
+    @Test(expected = UnexpectedStatusException.class)
+    public void testExecuteLimitedRelative4() throws Exception
+    {
+        HttpRequestExecutor executor = new Following(new Limited(3, new FollowStrategy()), new HttpUrlConnectionExecutor());
+
+        String response = executor.execute(URI.create("http://localhost:5000/redirect/6"), new StringHttpRequest());
+
+        System.out.println(response);
+    }
+
+
+    private static class StringHttpRequest implements HttpRequest<String>
+    {
+        @Override
+        public HttpMethod method()
+        {
+            return HttpMethod.GET;
+        }
+
+
+        @Override
+        public Headers headers()
+        {
+            return EmptyHeaders.INSTANCE;
+        }
+
+
+        @Override
+        public HttpRequestEntity requestEntity()
+        {
+            return EmptyHttpRequestEntity.INSTANCE;
+        }
+
+
+        @Override
+        public HttpResponseHandler<String> responseHandler(HttpResponse response)
+        {
+            return response.status().isSuccess() ? new StringResponseHandler() : new FailResponseHandler<>();
+        }
+    }
+}

--- a/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/policies/CompositeTest.java
+++ b/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/policies/CompositeTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import java.net.URI;
 
 import static org.dmfs.httpessentials.executors.following.policies.matcher.RedirectPolicyFollowMatcher.follows;
-import static org.dmfs.httpessentials.executors.following.policies.matcher.RedirectPolicyFollowMatcher.mockRedirect;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.mockRedirect;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 

--- a/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/policies/FollowPolicyTest.java
+++ b/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/policies/FollowPolicyTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import java.net.URI;
 
 import static org.dmfs.httpessentials.executors.following.policies.matcher.RedirectPolicyFollowMatcher.follows;
-import static org.dmfs.httpessentials.executors.following.policies.matcher.RedirectPolicyFollowMatcher.mockRedirect;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.mockRedirect;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 

--- a/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/policies/FollowRedirectPolicyTest.java
+++ b/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/policies/FollowRedirectPolicyTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import java.net.URI;
 
 import static org.dmfs.httpessentials.executors.following.policies.matcher.RedirectPolicyFollowMatcher.follows;
-import static org.dmfs.httpessentials.executors.following.policies.matcher.RedirectPolicyFollowMatcher.mockRedirect;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.mockRedirect;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 

--- a/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/policies/RelativeTest.java
+++ b/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/policies/RelativeTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import java.net.URI;
 
 import static org.dmfs.httpessentials.executors.following.policies.matcher.RedirectPolicyFollowMatcher.follows;
-import static org.dmfs.httpessentials.executors.following.policies.matcher.RedirectPolicyFollowMatcher.mockRedirect;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.mockRedirect;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 

--- a/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/policies/SecureTest.java
+++ b/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/policies/SecureTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import java.net.URI;
 
 import static org.dmfs.httpessentials.executors.following.policies.matcher.RedirectPolicyFollowMatcher.follows;
-import static org.dmfs.httpessentials.executors.following.policies.matcher.RedirectPolicyFollowMatcher.mockRedirect;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.mockRedirect;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 

--- a/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/policies/TemporaryTest.java
+++ b/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/policies/TemporaryTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import java.net.URI;
 
 import static org.dmfs.httpessentials.executors.following.policies.matcher.RedirectPolicyFollowMatcher.follows;
-import static org.dmfs.httpessentials.executors.following.policies.matcher.RedirectPolicyFollowMatcher.mockRedirect;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.mockRedirect;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 

--- a/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/policies/matcher/RedirectPolicyFollowMatcher.java
+++ b/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/policies/matcher/RedirectPolicyFollowMatcher.java
@@ -48,40 +48,6 @@ public final class RedirectPolicyFollowMatcher extends TypeSafeDiagnosingMatcher
     private final int mAttempt;
 
 
-    public static HttpResponse mockRedirect(HttpStatus status, URI source, URI location)
-    {
-        return new CustomUrisMockResponse(new StaticMockResponse(status, new SingletonHeaders(LOCATION.entity(location)), new HttpResponseEntity()
-        {
-            @Override
-            public Optional<MediaType> contentType()
-            {
-                return absent();
-            }
-
-
-            @Override
-            public Optional<Long> contentLength()
-            {
-                return absent();
-            }
-
-
-            @Override
-            public InputStream contentStream() throws IOException
-            {
-                return new InputStream()
-                {
-                    @Override
-                    public int read() throws IOException
-                    {
-                        return -1;
-                    }
-                };
-            }
-        }), source, source);
-    }
-
-
     public static Matcher<RedirectPolicy> follows(HttpResponse response, URI destination, int attempt)
     {
         return new RedirectPolicyFollowMatcher(response, destination, attempt);

--- a/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/CompositeTest.java
+++ b/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/CompositeTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies;
+
+import org.dmfs.httpessentials.HttpStatus;
+import org.dmfs.jems.optional.elementary.Absent;
+import org.dmfs.jems.optional.elementary.Present;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.follows;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.mockRedirect;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.notFollows;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link Composite}.
+ *
+ * @author marten
+ */
+public class CompositeTest
+{
+    @Test
+    public void testFollows()
+    {
+        assertThat(
+                new Composite(new FollowStrategy()),
+                follows(
+                        mockRedirect(
+                                HttpStatus.FOUND,
+                                URI.create("https://example.com/test"),
+                                URI.create("https://example.net")),
+                        1,
+                        URI.create("https://example.net")));
+        assertThat(
+                new Composite(
+                        (response, redirectNumber) -> new Absent<>(),
+                        (response, redirectNumber) -> new Present<>(URI.create("http://1.com"))),
+                follows(
+                        mockRedirect(
+                                HttpStatus.FOUND,
+                                URI.create("https://example.com/test"),
+                                URI.create("https://example.net")),
+                        1,
+                        URI.create("http://1.com")));
+    }
+
+
+    @Test
+    public void testNotFollows()
+    {
+        assertThat(
+                new Composite(new NeverFollowStrategy(), new NeverFollowStrategy(), new NeverFollowStrategy()),
+                notFollows(
+                        mockRedirect(
+                                HttpStatus.OK,
+                                URI.create("https://example.com/test"),
+                                URI.create("https://example.net")),
+                        1));
+    }
+}

--- a/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/FollowStrategyTest.java
+++ b/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/FollowStrategyTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies;
+
+import org.dmfs.httpessentials.HttpStatus;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.follows;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.mockRedirect;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.notFollows;
+import static org.hamcrest.core.AllOf.allOf;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link Temporary}.
+ */
+public class FollowStrategyTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(
+                new FollowStrategy(),
+                allOf(
+                        follows(
+                                mockRedirect(
+                                        HttpStatus.TEMPORARY_REDIRECT,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1,
+                                URI.create("http:://example.com")),
+                        follows(
+                                mockRedirect(
+                                        HttpStatus.FOUND,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                10,
+                                URI.create("http:://example.com")),
+                        follows(
+                                mockRedirect(
+                                        HttpStatus.PERMANENT_REDIRECT,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                100,
+                                URI.create("http:://example.com")),
+                        follows(
+                                mockRedirect(
+                                        HttpStatus.MOVED_PERMANENTLY,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1000,
+                                URI.create("http:://example.com")),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.NOT_MODIFIED,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.SEE_OTHER,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.OK,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1)));
+
+    }
+}

--- a/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/LimitedTest.java
+++ b/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/LimitedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 dmfs GmbH
+ * Copyright 2020 dmfs GmbH
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,16 +15,16 @@
  * limitations under the License.
  */
 
-package org.dmfs.httpessentials.executors.following.policies;
+package org.dmfs.httpessentials.executors.following.strategies;
 
 import org.dmfs.httpessentials.HttpStatus;
 import org.junit.Test;
 
 import java.net.URI;
 
-import static org.dmfs.httpessentials.executors.following.policies.matcher.RedirectPolicyFollowMatcher.follows;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.follows;
 import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.mockRedirect;
-import static org.hamcrest.Matchers.not;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.notFollows;
 import static org.junit.Assert.assertThat;
 
 
@@ -38,123 +38,103 @@ public class LimitedTest
     @Test
     public void testFollow()
     {
-        assertThat(new Limited(5, new FollowPolicy()),
+        assertThat(new Limited(3, new FollowStrategy()),
                 follows(
                         mockRedirect(
                                 HttpStatus.PERMANENT_REDIRECT,
                                 URI.create("https://example.com/test"),
                                 URI.create("https://example.net")),
-                        URI.create("https://example.net"),
-                        1));
-        assertThat(new Limited(5, new FollowPolicy()),
+                        1,
+                        URI.create("https://example.net")));
+        assertThat(new Limited(3, new FollowStrategy()),
                 follows(
                         mockRedirect(
                                 HttpStatus.PERMANENT_REDIRECT,
                                 URI.create("https://example.com/test"),
                                 URI.create("https://example.net")),
-                        URI.create("https://example.net"),
-                        2));
-        assertThat(new Limited(5, new FollowPolicy()),
+                        2,
+                        URI.create("https://example.net")));
+        assertThat(new Limited(3, new FollowStrategy()),
                 follows(
                         mockRedirect(
                                 HttpStatus.PERMANENT_REDIRECT,
                                 URI.create("https://example.com/test"),
                                 URI.create("https://example.net")),
-                        URI.create("https://example.net"),
-                        3));
-        assertThat(new Limited(5, new FollowPolicy()),
+                        3,
+                        URI.create("https://example.net")));
+        assertThat(new Limited(new FollowStrategy()),
                 follows(
                         mockRedirect(
                                 HttpStatus.PERMANENT_REDIRECT,
                                 URI.create("https://example.com/test"),
                                 URI.create("https://example.net")),
-                        URI.create("https://example.net"),
-                        4));
-        assertThat(new Limited(5, new FollowPolicy()),
+                        1,
+                        URI.create("https://example.net")));
+        assertThat(new Limited(new FollowStrategy()),
                 follows(
                         mockRedirect(
                                 HttpStatus.PERMANENT_REDIRECT,
                                 URI.create("https://example.com/test"),
                                 URI.create("https://example.net")),
-                        URI.create("https://example.net"),
-                        5));
-        assertThat(new Limited(new FollowPolicy()),
+                        2,
+                        URI.create("https://example.net")));
+        assertThat(new Limited(new FollowStrategy()),
                 follows(
                         mockRedirect(
                                 HttpStatus.PERMANENT_REDIRECT,
                                 URI.create("https://example.com/test"),
                                 URI.create("https://example.net")),
-                        URI.create("https://example.net"),
-                        1));
-        assertThat(new Limited(new FollowPolicy()),
+                        3,
+                        URI.create("https://example.net")));
+        assertThat(new Limited(new FollowStrategy()),
                 follows(
                         mockRedirect(
                                 HttpStatus.PERMANENT_REDIRECT,
                                 URI.create("https://example.com/test"),
                                 URI.create("https://example.net")),
-                        URI.create("https://example.net"),
-                        2));
-        assertThat(new Limited(new FollowPolicy()),
+                        4,
+                        URI.create("https://example.net")));
+        assertThat(new Limited(new FollowStrategy()),
                 follows(
                         mockRedirect(
                                 HttpStatus.PERMANENT_REDIRECT,
                                 URI.create("https://example.com/test"),
                                 URI.create("https://example.net")),
-                        URI.create("https://example.net"),
-                        3));
-        assertThat(new Limited(new FollowPolicy()),
-                follows(
-                        mockRedirect(
-                                HttpStatus.PERMANENT_REDIRECT,
-                                URI.create("https://example.com/test"),
-                                URI.create("https://example.net")),
-                        URI.create("https://example.net"),
-                        4));
-        assertThat(new Limited(new FollowPolicy()),
-                follows(
-                        mockRedirect(
-                                HttpStatus.PERMANENT_REDIRECT,
-                                URI.create("https://example.com/test"),
-                                URI.create("https://example.net")),
-                        URI.create("https://example.net"),
-                        5));
+                        5,
+                        URI.create("https://example.net")));
     }
 
 
     @Test
     public void testNoFollow()
     {
-        assertThat(new Limited(5, new NeverFollowRedirectPolicy()),
-                not(follows(
+        assertThat(new Limited(3, new NeverFollowStrategy()),
+                notFollows(
                         mockRedirect(
                                 HttpStatus.PERMANENT_REDIRECT,
                                 URI.create("https://example.com/test"),
                                 URI.create("https://example.net")),
-                        URI.create("https://example.net"),
-                        1)));
-        assertThat(new Limited(5, new FollowPolicy()),
-                not(follows(
+                        1));
+        assertThat(new Limited(3, new FollowStrategy()),
+                notFollows(
                         mockRedirect(
                                 HttpStatus.OK,
                                 URI.create("https://example.com/test"),
                                 URI.create("https://example.net")),
-                        URI.create("https://example.net"),
-                        1)));
-        assertThat(new Limited(5, new FollowPolicy()),
-                not(follows(
+                        1));
+        assertThat(new Limited(3, new FollowStrategy()),
+                notFollows(
                         mockRedirect(
                                 HttpStatus.PERMANENT_REDIRECT,
                                 URI.create("https://example.com/test"),
                                 URI.create("https://example.net")),
-                        URI.create("https://example.net"),
-                        6)));
-        assertThat(new Limited(new FollowPolicy()),
-                not(follows(
+                        4));
+        assertThat(new Limited(new FollowStrategy()),
+                notFollows(
                         mockRedirect(
                                 HttpStatus.PERMANENT_REDIRECT,
                                 URI.create("https://example.com/test"),
                                 URI.create("https://example.net")),
-                        URI.create("https://example.net"),
-                        6)));
+                        6));
     }
 }

--- a/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/NeverFollowStrategyTest.java
+++ b/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/NeverFollowStrategyTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies;
+
+import org.dmfs.httpessentials.HttpStatus;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.mockRedirect;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.notFollows;
+import static org.hamcrest.core.AllOf.allOf;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link NeverFollowStrategy}.
+ */
+public class NeverFollowStrategyTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(
+                new NeverFollowStrategy(),
+                allOf(
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.TEMPORARY_REDIRECT,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.FOUND,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                10),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.PERMANENT_REDIRECT,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                100),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.MOVED_PERMANENTLY,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1000),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.NOT_MODIFIED,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.SEE_OTHER,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.OK,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1)));
+
+    }
+}

--- a/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/PermanentTest.java
+++ b/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/PermanentTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies;
+
+import org.dmfs.httpessentials.HttpStatus;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.follows;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.mockRedirect;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.notFollows;
+import static org.hamcrest.core.AllOf.allOf;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link Temporary}.
+ */
+public class PermanentTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(
+                new Permanent(new FollowStrategy()),
+                allOf(
+                        follows(
+                                mockRedirect(
+                                        HttpStatus.PERMANENT_REDIRECT,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1,
+                                URI.create("http:://example.com")),
+                        follows(
+                                mockRedirect(
+                                        HttpStatus.MOVED_PERMANENTLY,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1,
+                                URI.create("http:://example.com")),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.TEMPORARY_REDIRECT,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.FOUND,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1)));
+
+        assertThat(
+                new Permanent(new NeverFollowStrategy()),
+                allOf(
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.TEMPORARY_REDIRECT,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.FOUND,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.PERMANENT_REDIRECT,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.MOVED_PERMANENTLY,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1)));
+
+    }
+}

--- a/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/SameAuthorityTest.java
+++ b/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/SameAuthorityTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies;
+
+import org.dmfs.httpessentials.HttpStatus;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.follows;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.mockRedirect;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.notFollows;
+import static org.hamcrest.Matchers.allOf;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link SameAuthority}.
+ */
+public class SameAuthorityTest
+{
+
+    @Test
+    public void testFollow()
+    {
+        assertThat(new SameAuthority(new FollowStrategy()),
+                allOf(
+                        follows(
+                                mockRedirect(
+                                        HttpStatus.PERMANENT_REDIRECT,
+                                        URI.create("https://example.com/test"),
+                                        URI.create("https://example.com/new")),
+                                1,
+                                URI.create("https://example.com/new")),
+                        follows(
+                                mockRedirect(
+                                        HttpStatus.PERMANENT_REDIRECT,
+                                        URI.create("https://example.com/test"),
+                                        URI.create("//example.com/new")),
+                                1,
+                                URI.create("https://example.com/new")),
+                        follows(
+                                mockRedirect(
+                                        HttpStatus.PERMANENT_REDIRECT,
+                                        URI.create("https://example.com/test"),
+                                        URI.create("/new")),
+                                1,
+                                URI.create("https://example.com/new"))));
+    }
+
+
+    @Test
+    public void testNoFollow()
+    {
+        assertThat(new SameAuthority(new NeverFollowStrategy()),
+                notFollows(
+                        mockRedirect(
+                                HttpStatus.PERMANENT_REDIRECT,
+                                URI.create("https://example.com/test"),
+                                URI.create("/new")),
+                        1));
+        assertThat(new SameAuthority(new FollowStrategy()),
+                allOf(
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.PERMANENT_REDIRECT,
+                                        URI.create("https://example.com/test"),
+                                        URI.create("https://example.net")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.PERMANENT_REDIRECT,
+                                        URI.create("https://example.com/test"),
+                                        URI.create("http://example.com/new")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.PERMANENT_REDIRECT,
+                                        URI.create("https://example.com/test"),
+                                        URI.create("//example.net")),
+                                1)));
+    }
+}

--- a/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/SecureTest.java
+++ b/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/SecureTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies;
+
+import org.dmfs.httpessentials.HttpStatus;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.follows;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.mockRedirect;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.notFollows;
+import static org.hamcrest.core.AllOf.allOf;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link Secure}.
+ */
+public class SecureTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(
+                new Secure(new FollowStrategy()),
+                allOf(
+                        follows(
+                                mockRedirect(
+                                        HttpStatus.TEMPORARY_REDIRECT,
+                                        URI.create("https:://example.org"),
+                                        URI.create("https:://example.com")),
+                                1,
+                                URI.create("https:://example.com")),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.TEMPORARY_REDIRECT,
+                                        URI.create("https:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.TEMPORARY_REDIRECT,
+                                        URI.create("http:://example.org"),
+                                        URI.create("https:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.TEMPORARY_REDIRECT,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1)));
+
+        assertThat(
+                new Secure(new NeverFollowStrategy()),
+                allOf(
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.TEMPORARY_REDIRECT,
+                                        URI.create("https:://example.org"),
+                                        URI.create("https:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.TEMPORARY_REDIRECT,
+                                        URI.create("https:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.TEMPORARY_REDIRECT,
+                                        URI.create("http:://example.org"),
+                                        URI.create("https:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.TEMPORARY_REDIRECT,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1)));
+    }
+}

--- a/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/TemporaryTest.java
+++ b/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/TemporaryTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies;
+
+import org.dmfs.httpessentials.HttpStatus;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.follows;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.mockRedirect;
+import static org.dmfs.httpessentials.executors.following.strategies.matcher.RedirectStrategyFollowMatcher.notFollows;
+import static org.hamcrest.core.AllOf.allOf;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link Temporary}.
+ */
+public class TemporaryTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(
+                new Temporary(new FollowStrategy()),
+                allOf(
+                        follows(
+                                mockRedirect(
+                                        HttpStatus.TEMPORARY_REDIRECT,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1,
+                                URI.create("http:://example.com")),
+                        follows(
+                                mockRedirect(
+                                        HttpStatus.FOUND,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1,
+                                URI.create("http:://example.com")),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.PERMANENT_REDIRECT,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.MOVED_PERMANENTLY,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1)));
+
+        assertThat(
+                new Temporary(new NeverFollowStrategy()),
+                allOf(
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.TEMPORARY_REDIRECT,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.FOUND,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.PERMANENT_REDIRECT,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1),
+                        notFollows(
+                                mockRedirect(
+                                        HttpStatus.MOVED_PERMANENTLY,
+                                        URI.create("http:://example.org"),
+                                        URI.create("http:://example.com")),
+                                1)));
+
+    }
+}

--- a/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/matcher/RedirectStrategyFollowMatcher.java
+++ b/http-executor-decorators/src/test/java/org/dmfs/httpessentials/executors/following/strategies/matcher/RedirectStrategyFollowMatcher.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.executors.following.strategies.matcher;
+
+import org.dmfs.httpessentials.HttpStatus;
+import org.dmfs.httpessentials.client.HttpResponse;
+import org.dmfs.httpessentials.executors.following.RedirectStrategy;
+import org.dmfs.httpessentials.headers.SingletonHeaders;
+import org.dmfs.httpessentials.mockutils.entities.StaticMockResponseEntity;
+import org.dmfs.httpessentials.mockutils.responses.CustomUrisMockResponse;
+import org.dmfs.httpessentials.mockutils.responses.StaticMockResponse;
+import org.hamcrest.Matcher;
+
+import java.net.URI;
+
+import static org.dmfs.httpessentials.headers.HttpHeaders.LOCATION;
+import static org.dmfs.jems.hamcrest.matchers.LambdaMatcher.having;
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
+import static org.hamcrest.Matchers.is;
+
+
+/**
+ * @author Marten Gajda
+ */
+public final class RedirectStrategyFollowMatcher
+{
+
+    public static HttpResponse mockRedirect(HttpStatus status, URI source, URI location)
+    {
+        return new CustomUrisMockResponse(
+                new StaticMockResponse(status,
+                        new SingletonHeaders(LOCATION.entity(location)),
+                        new StaticMockResponseEntity()),
+                source, source);
+    }
+
+
+    public static Matcher<? super RedirectStrategy> follows(HttpResponse response, int attempt, URI destination)
+    {
+        return having(
+                strategy -> strategy.location(response, attempt),
+                is(present(destination)));
+    }
+
+
+    public static Matcher<? super RedirectStrategy> notFollows(HttpResponse response, int attempt)
+    {
+        return having(
+                strategy -> strategy.location(response, attempt),
+                absent());
+    }
+
+}


### PR DESCRIPTION
In order to guarantee backwards compatibility, RedirectPolicy extends RedirectStrategy and the old implementations have been deprecated.

@lemonboston this is low prio and not relevant for 0.15.1