### PR TITLE
Automatically publish to snapshots. Implements #95

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,16 @@
-
 apply plugin: 'java'
+
+def isSnapshot = { ->
+    def stdout = new ByteArrayOutputStream()
+    def errout = new ByteArrayOutputStream()
+    def result = exec {
+        commandLine 'git', 'describe', '--exact-match', '--tag', 'HEAD'
+        standardOutput = stdout
+        errorOutput = errout
+        ignoreExitValue = true
+    }
+    return result.exitValue != 0
+}
 
 def gitVersion = { ->
     def stdout = new ByteArrayOutputStream()
@@ -7,7 +18,7 @@ def gitVersion = { ->
         commandLine 'git', 'describe', '--tags'
         standardOutput = stdout
     }
-    return stdout.toString().trim()
+    return isSnapshot() ? stdout.toString().trim() + "-SNAPSHOT" : stdout.toString().trim()
 }
 
 sourceCompatibility = 1.7
@@ -25,3 +36,8 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
 }
 
+task printVersion {
+    doLast {
+        println project.version
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 RELEASE_REPOSITORY=https://oss.sonatype.org/service/local/staging/deploy/maven2
+SNAPSHOT_REPOSITORY=https://oss.sonatype.org/content/repositories/snapshots
 POM_DEVELOPER_ID=dmfs
 POM_DEVELOPER_NAME=Marten Gajda
 POM_DEVELOPER_EMAIL=marten@dmfs.org

--- a/publish.gradle
+++ b/publish.gradle
@@ -60,7 +60,7 @@ if (project.hasProperty('SONATYPE_USERNAME') && project.hasProperty('SONATYPE_PA
         repositories {
             maven {
                 name 'release'
-                url RELEASE_REPOSITORY
+                url version.endsWith("-SNAPSHOT") ? SNAPSHOT_REPOSITORY : RELEASE_REPOSITORY
                 credentials {
                     username SONATYPE_USERNAME
                     password SONATYPE_PASSWORD


### PR DESCRIPTION
This commit makes sure artifacts are published to the snapshot repository if the current commit (the one being published) is not tagged. Tagged builds are still published to the release repo.

@lemonboston you can't test the publishing part, so maybe just check if it looks "reasonable". FYI: in order to publish the the snapshot repo, version numbers must end with "-SNAPSHOT".