### PR TITLE
BinaryRequestEntity. Implements #104

### DIFF
--- a/http-client-basics/src/main/java/org/dmfs/httpessentials/entities/BinaryRequestEntity.java
+++ b/http-client-basics/src/main/java/org/dmfs/httpessentials/entities/BinaryRequestEntity.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.entities;
+
+import org.dmfs.httpessentials.client.HttpRequestEntity;
+import org.dmfs.httpessentials.types.MediaType;
+import org.dmfs.jems.single.Single;
+import org.dmfs.optional.Optional;
+import org.dmfs.optional.Present;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+
+/**
+ * A basic {@link HttpRequestEntity} with binary data. This is meant to be used as a delegate for higher level request entities.
+ * <p>
+ * Note, this is meant to be used for requests with a message body and always expects a valid {@link MediaType}.
+ *
+ * @author Marten Gajda
+ */
+public final class BinaryRequestEntity implements HttpRequestEntity
+{
+    private final MediaType mMediaType;
+    private final Single<byte[]> mData;
+
+
+    public BinaryRequestEntity(MediaType mediaType, Single<byte[]> data)
+    {
+        mMediaType = mediaType;
+        mData = data;
+    }
+
+
+    @Override
+    public Optional<MediaType> contentType()
+    {
+        return new Present<>(mMediaType);
+    }
+
+
+    @Override
+    public Optional<Long> contentLength()
+    {
+        return new Present<>((long) mData.value().length);
+    }
+
+
+    @Override
+    public void writeContent(OutputStream out) throws IOException
+    {
+        out.write(mData.value());
+    }
+}

--- a/http-client-basics/src/main/java/org/dmfs/httpessentials/entities/DelegatingRequestEntity.java
+++ b/http-client-basics/src/main/java/org/dmfs/httpessentials/entities/DelegatingRequestEntity.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.entities;
+
+import org.dmfs.httpessentials.client.HttpRequestEntity;
+import org.dmfs.httpessentials.types.MediaType;
+import org.dmfs.optional.Optional;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+
+/**
+ * An abstract {@link HttpRequestEntity} which delegates all calls to another {@link HttpRequestEntity}.
+ *
+ * @author Marten Gajda
+ */
+public abstract class DelegatingRequestEntity implements HttpRequestEntity
+{
+    private final HttpRequestEntity mDelegate;
+
+
+    public DelegatingRequestEntity(HttpRequestEntity delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public final Optional<MediaType> contentType()
+    {
+        return mDelegate.contentType();
+    }
+
+
+    @Override
+    public final Optional<Long> contentLength()
+    {
+        return mDelegate.contentLength();
+    }
+
+
+    @Override
+    public final void writeContent(OutputStream out) throws IOException
+    {
+        mDelegate.writeContent(out);
+    }
+}

--- a/http-client-basics/src/test/java/org/dmfs/httpessentials/entities/BinaryRequestEntityTest.java
+++ b/http-client-basics/src/test/java/org/dmfs/httpessentials/entities/BinaryRequestEntityTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.entities;
+
+import org.dmfs.httpessentials.types.MediaType;
+import org.dmfs.httpessentials.types.StringMediaType;
+import org.dmfs.httpessentials.types.StructuredMediaType;
+import org.dmfs.jems.hamcrest.matchers.PresentMatcher;
+import org.dmfs.jems.single.Single;
+import org.dmfs.jems.single.elementary.ValueSingle;
+import org.junit.Test;
+
+import java.io.OutputStream;
+
+import static org.dmfs.jems.hamcrest.matchers.PresentMatcher.isPresent;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class BinaryRequestEntityTest
+{
+    @Test
+    public void testContentType() throws Exception
+    {
+        assertThat(new BinaryRequestEntity(new StructuredMediaType("application", "text"), dummy(Single.class)).contentType(),
+                PresentMatcher.<MediaType>isPresent(new StringMediaType("application/text")));
+    }
+
+
+    @Test
+    public void testContentLength() throws Exception
+    {
+        assertThat(new BinaryRequestEntity(dummy(MediaType.class), new ValueSingle<>(new byte[0])).contentLength(), isPresent(0L));
+        assertThat(new BinaryRequestEntity(dummy(MediaType.class), new ValueSingle<>(new byte[1000])).contentLength(), isPresent(1000L));
+    }
+
+
+    @Test
+    public void testWriteContent() throws Exception
+    {
+        byte[] dummyData = new byte[1000];
+        OutputStream mockStream = failingMock(OutputStream.class);
+        doNothing().when(mockStream).write(dummyData);
+
+        new BinaryRequestEntity(dummy(MediaType.class), new ValueSingle<>(dummyData)).writeContent(mockStream);
+
+        // make sure the data has actually been written
+        verify(mockStream).write(dummyData);
+    }
+
+}

--- a/http-client-basics/src/test/java/org/dmfs/httpessentials/entities/DelegatingRequestEntityTest.java
+++ b/http-client-basics/src/test/java/org/dmfs/httpessentials/entities/DelegatingRequestEntityTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.entities;
+
+import org.dmfs.httpessentials.client.HttpRequestEntity;
+import org.dmfs.httpessentials.types.MediaType;
+import org.dmfs.optional.Optional;
+import org.junit.Test;
+
+import java.io.OutputStream;
+
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class DelegatingRequestEntityTest
+{
+    @Test
+    public void testContentType() throws Exception
+    {
+        HttpRequestEntity mockEntity = failingMock(HttpRequestEntity.class);
+        Optional<MediaType> dummyOptional = dummy(Optional.class);
+        doReturn(dummyOptional).when(mockEntity).contentType();
+
+        assertThat(new DelegatingTestEntity(mockEntity).contentType(), sameInstance(dummyOptional));
+    }
+
+
+    @Test
+    public void testContentLength() throws Exception
+    {
+        HttpRequestEntity mockEntity = failingMock(HttpRequestEntity.class);
+        Optional<Long> dummyOptional = dummy(Optional.class);
+        doReturn(dummyOptional).when(mockEntity).contentLength();
+
+        assertThat(new DelegatingTestEntity(mockEntity).contentLength(), sameInstance(dummyOptional));
+    }
+
+
+    @Test
+    public void testWriteContent() throws Exception
+    {
+        OutputStream dummyStream = dummy(OutputStream.class);
+
+        HttpRequestEntity mockEntity = failingMock(HttpRequestEntity.class);
+        doNothing().when(mockEntity).writeContent(dummyStream);
+
+        new DelegatingTestEntity(mockEntity).writeContent(dummyStream);
+        verify(mockEntity).writeContent(dummyStream);
+    }
+
+
+    private final static class DelegatingTestEntity extends DelegatingRequestEntity
+    {
+
+        public DelegatingTestEntity(HttpRequestEntity delegate)
+        {
+            super(delegate);
+        }
+    }
+}


### PR DESCRIPTION
This adds a `BinaryRequestEntity` which takes a `Single<byte[]>`. It can be used to compose `HttpRequestEntities` for complex types which can be converted to an array of bytes.
This also adds a `DelegatingRequestEntity` which can serve as the abstract base of such a delegating request entity.