### PR TITLE
Add basic HttpRequestEntity implementations. Implements #106

### DIFF
--- a/http-client-basics/build.gradle
+++ b/http-client-basics/build.gradle
@@ -18,6 +18,10 @@ dependencies {
     compile project(':http-client-essentials')
     compile project(':http-client-types')
     compile project(':http-client-headers')
+    compile 'org.dmfs:rfc3986-uri:0.8'
+    compileOnly 'org.json:json:20171018'
+
+    testCompile 'org.json:json:20171018'
     testCompile 'junit:junit:' + JUNIT_VERSION
     testCompile 'org.dmfs:jems-testing:' + JEMS_VERSION
 }

--- a/http-client-basics/src/main/java/org/dmfs/httpessentials/entities/JsonRequestEntity.java
+++ b/http-client-basics/src/main/java/org/dmfs/httpessentials/entities/JsonRequestEntity.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.entities;
+
+import org.dmfs.httpessentials.client.HttpRequestEntity;
+import org.dmfs.httpessentials.types.StructuredMediaType;
+import org.dmfs.jems.single.Single;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+
+/**
+ * An {@link HttpRequestEntity} for JSON data.
+ *
+ * @author Marten Gajda
+ */
+public final class JsonRequestEntity extends DelegatingRequestEntity
+{
+    public JsonRequestEntity(final JSONArray jsonArray)
+    {
+        this(new Single<CharSequence>()
+        {
+            @Override
+            public CharSequence value()
+            {
+                return jsonArray.toString();
+            }
+        });
+    }
+
+
+    public JsonRequestEntity(final JSONObject jsonObject)
+    {
+        this(new Single<CharSequence>()
+        {
+            @Override
+            public CharSequence value()
+            {
+                return jsonObject.toString();
+            }
+        });
+    }
+
+
+    private JsonRequestEntity(final Single<CharSequence> jsonString)
+    {
+        // Note: There is no charset parameter specified for application/json. A JSON file is supposed to be in Unicode.
+        // Whether it's UTF-8, UTF-16BE, UTF-16LE or UTF-32 should be determined by looking at the first 2 or 4 bytes.
+        super(new TextRequestEntity(
+                new StructuredMediaType("application", "json"),
+                jsonString));
+    }
+}

--- a/http-client-basics/src/main/java/org/dmfs/httpessentials/entities/TextRequestEntity.java
+++ b/http-client-basics/src/main/java/org/dmfs/httpessentials/entities/TextRequestEntity.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.entities;
+
+import org.dmfs.httpessentials.client.HttpRequestEntity;
+import org.dmfs.httpessentials.types.MediaType;
+import org.dmfs.jems.single.Single;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Locale;
+
+
+/**
+ * An {@link HttpRequestEntity} with character data. If the given {@link MediaType} doesn't specify any encoding this will fall back to utf-8.
+ *
+ * @author Marten Gajda
+ */
+public final class TextRequestEntity extends DelegatingRequestEntity
+{
+    public TextRequestEntity(final MediaType mediaType, final Single<CharSequence> charSequence)
+    {
+        super(new BinaryRequestEntity(mediaType, new Single<byte[]>()
+        {
+            @Override
+            public byte[] value()
+            {
+                try
+                {
+                    return charSequence.value().toString().getBytes(mediaType.charset("utf-8"));
+                }
+                catch (UnsupportedEncodingException e)
+                {
+                    throw new RuntimeException(String.format(Locale.ENGLISH, "Encoding %s not supported by runtime", mediaType.charset("utf-8")), e);
+                }
+            }
+        }));
+    }
+}

--- a/http-client-basics/src/main/java/org/dmfs/httpessentials/entities/XWwwFormUrlEncodedEntity.java
+++ b/http-client-basics/src/main/java/org/dmfs/httpessentials/entities/XWwwFormUrlEncodedEntity.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.entities;
+
+import org.dmfs.httpessentials.client.HttpRequestEntity;
+import org.dmfs.httpessentials.types.StructuredMediaType;
+import org.dmfs.iterables.decorators.Mapped;
+import org.dmfs.iterators.Function;
+import org.dmfs.jems.pair.Pair;
+import org.dmfs.jems.single.Single;
+import org.dmfs.rfc3986.encoding.XWwwFormUrlEncoded;
+import org.dmfs.rfc3986.parameters.Parameter;
+import org.dmfs.rfc3986.parameters.ParameterList;
+import org.dmfs.rfc3986.parameters.parametersets.BasicParameterList;
+
+
+/**
+ * An {@link HttpRequestEntity} that encodes key-value pairs using <code>application/x-www-form-urlencoded</code> encoding.
+ *
+ * @author Marten Gajda
+ */
+public final class XWwwFormUrlEncodedEntity extends DelegatingRequestEntity
+{
+
+    public XWwwFormUrlEncodedEntity(Iterable<Pair<CharSequence, CharSequence>> values)
+    {
+        this(new BasicParameterList(
+                new Mapped<>(
+                        values,
+                        new Function<Pair<CharSequence, CharSequence>, Parameter>()
+                        {
+                            @Override
+                            public Parameter apply(final Pair<CharSequence, CharSequence> argument)
+                            {
+                                return new PairParameter(argument);
+                            }
+                        })));
+    }
+
+
+    // TODO: deprecate ParameterList and just use Iterable<Pair<CharSequence, CharSequence>>
+    public XWwwFormUrlEncodedEntity(final ParameterList values)
+    {
+        super(new TextRequestEntity(new StructuredMediaType("application", "x-www-form-urlencoded"),
+                new Single<CharSequence>()
+                {
+                    @Override
+                    public CharSequence value()
+                    {
+                        return new XWwwFormUrlEncoded(values);
+                    }
+                }));
+    }
+
+
+    private static class PairParameter implements Parameter
+    {
+        private final Pair<CharSequence, CharSequence> mKeyValuePair;
+
+
+        public PairParameter(Pair<CharSequence, CharSequence> keyValuePair)
+        {
+            mKeyValuePair = keyValuePair;
+        }
+
+
+        @Override
+        public CharSequence name()
+        {
+            return mKeyValuePair.left();
+        }
+
+
+        @Override
+        public CharSequence textValue()
+        {
+            return mKeyValuePair.right();
+        }
+    }
+}

--- a/http-client-basics/src/test/java/org/dmfs/httpessentials/entities/JsonRequestEntityTest.java
+++ b/http-client-basics/src/test/java/org/dmfs/httpessentials/entities/JsonRequestEntityTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.entities;
+
+import org.dmfs.httpessentials.types.MediaType;
+import org.dmfs.httpessentials.types.StringMediaType;
+import org.dmfs.jems.hamcrest.matchers.PresentMatcher;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
+import static org.dmfs.jems.hamcrest.matchers.PresentMatcher.isPresent;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class JsonRequestEntityTest
+{
+    @Test
+    public void testContentType()
+    {
+        assertThat(new JsonRequestEntity(new JSONObject()).contentType(), PresentMatcher.<MediaType>isPresent(new StringMediaType("application/json")));
+        assertThat(new JsonRequestEntity(new JSONArray()).contentType(), PresentMatcher.<MediaType>isPresent(new StringMediaType("application/json")));
+    }
+
+
+    @Test
+    public void testJSONObjectContentLength() throws UnsupportedEncodingException
+    {
+        JSONObject mockObject = failingMock(JSONObject.class);
+        doReturn("dummyStringäöü").when(mockObject).toString();
+        assertThat(new JsonRequestEntity(mockObject).contentLength(), isPresent((long) "dummyStringäöü".getBytes("utf-8").length));
+    }
+
+
+    @Test
+    public void testJSONArrayContentLength() throws UnsupportedEncodingException
+    {
+        JSONArray mockArray = failingMock(JSONArray.class);
+        doReturn("dummyStringäöü").when(mockArray).toString();
+        assertThat(new JsonRequestEntity(mockArray).contentLength(), isPresent((long) "dummyStringäöü".getBytes("utf-8").length));
+    }
+
+
+    @Test
+    public void testJSONObjectContent() throws IOException
+    {
+        JSONObject mockObject = failingMock(JSONObject.class);
+        doReturn("dummyStringäöü").when(mockObject).toString();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        new JsonRequestEntity(mockObject).writeContent(out);
+
+        assertThat(out.toByteArray(), is("dummyStringäöü".getBytes("utf-8")));
+    }
+
+
+    @Test
+    public void testJSONArrayContent() throws IOException
+    {
+        JSONArray mockArray = failingMock(JSONArray.class);
+        doReturn("dummyStringäöü").when(mockArray).toString();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        new JsonRequestEntity(mockArray).writeContent(out);
+
+        assertThat(out.toByteArray(), is("dummyStringäöü".getBytes("utf-8")));
+    }
+}

--- a/http-client-basics/src/test/java/org/dmfs/httpessentials/entities/TextRequestEntityTest.java
+++ b/http-client-basics/src/test/java/org/dmfs/httpessentials/entities/TextRequestEntityTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.entities;
+
+import org.dmfs.httpessentials.types.MediaType;
+import org.dmfs.jems.single.Single;
+import org.dmfs.jems.single.elementary.ValueSingle;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.dmfs.jems.hamcrest.matchers.PresentMatcher.isPresent;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class TextRequestEntityTest
+{
+    @Test
+    public void testContentType()
+    {
+        MediaType dummy = dummy(MediaType.class);
+        assertThat(new TextRequestEntity(dummy, dummy(Single.class)).contentType(), isPresent(sameInstance(dummy)));
+    }
+
+
+    @Test
+    public void testContentLengthEmpty()
+    {
+        MediaType mockMediaType = failingMock(MediaType.class);
+        doReturn("utf-8").when(mockMediaType).charset("utf-8");
+        assertThat(new TextRequestEntity(mockMediaType, new ValueSingle<CharSequence>("")).contentLength(), isPresent(0L));
+    }
+
+
+    @Test
+    public void testContentLengthUtf8()
+    {
+        // utf-8 encodes äöü as 2 bytes each
+        MediaType mockMediaType = failingMock(MediaType.class);
+        doReturn("utf-8").when(mockMediaType).charset("utf-8");
+        assertThat(new TextRequestEntity(mockMediaType, new ValueSingle<CharSequence>("abcäöü")).contentLength(), isPresent(9L));
+    }
+
+
+    @Test
+    public void testContentLengthLatin1()
+    {
+        // latin1 encodes äöü as 1 byte each
+        MediaType mockMediaType = failingMock(MediaType.class);
+        doReturn("latin1").when(mockMediaType).charset("utf-8");
+        assertThat(new TextRequestEntity(mockMediaType, new ValueSingle<CharSequence>("abcäöü")).contentLength(), isPresent(6L));
+    }
+
+
+    @Test
+    public void testContentUtf8() throws IOException
+    {
+        // latin1 encodes äöü as 1 byte each
+        MediaType mockMediaType = failingMock(MediaType.class);
+        doReturn("utf-8").when(mockMediaType).charset("utf-8");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        new TextRequestEntity(mockMediaType, new ValueSingle<CharSequence>("abcäöü")).writeContent(out);
+
+        assertThat(out.toByteArray(), is("abcäöü".getBytes("utf-8")));
+    }
+
+
+    @Test
+    public void testContentLatin1() throws IOException
+    {
+        // latin1 encodes äöü as 1 byte each
+        MediaType mockMediaType = failingMock(MediaType.class);
+        doReturn("latin1").when(mockMediaType).charset("utf-8");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        new TextRequestEntity(mockMediaType, new ValueSingle<CharSequence>("abcäöü")).writeContent(out);
+
+        assertThat(out.toByteArray(), is("abcäöü".getBytes("latin1")));
+    }
+}

--- a/http-client-basics/src/test/java/org/dmfs/httpessentials/entities/XWwwFormUrlEncodedEntityTest.java
+++ b/http-client-basics/src/test/java/org/dmfs/httpessentials/entities/XWwwFormUrlEncodedEntityTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.httpessentials.entities;
+
+import org.dmfs.httpessentials.types.MediaType;
+import org.dmfs.httpessentials.types.StringMediaType;
+import org.dmfs.iterables.EmptyIterable;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.hamcrest.matchers.PresentMatcher;
+import org.dmfs.jems.pair.Pair;
+import org.dmfs.jems.pair.elementary.ValuePair;
+import org.dmfs.rfc3986.parameters.parametersets.EmptyParameterList;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
+import static org.dmfs.jems.hamcrest.matchers.PresentMatcher.isPresent;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class XWwwFormUrlEncodedEntityTest
+{
+    @Test
+    public void testContentType()
+    {
+        assertThat(new XWwwFormUrlEncodedEntity(new EmptyIterable<Pair<CharSequence, CharSequence>>()).contentType(),
+                PresentMatcher.<MediaType>isPresent(new StringMediaType("application/x-www-form-urlencoded")));
+        assertThat(new XWwwFormUrlEncodedEntity(new EmptyParameterList()).contentType(),
+                PresentMatcher.<MediaType>isPresent(new StringMediaType("application/x-www-form-urlencoded")));
+    }
+
+
+    @Test
+    public void testContentLength() throws UnsupportedEncodingException
+    {
+        assertThat(new XWwwFormUrlEncodedEntity(
+                new EmptyIterable<Pair<CharSequence, CharSequence>>()).contentLength(), isPresent(0L));
+
+        assertThat(new XWwwFormUrlEncodedEntity(
+                        new Seq<Pair<CharSequence, CharSequence>>(new ValuePair<CharSequence, CharSequence>("key", "valueäöü"))).contentLength(),
+                isPresent((long) "key=value%C3%A4%C3%B6%C3%BC".getBytes("UTF-8").length));
+
+        assertThat(new XWwwFormUrlEncodedEntity(
+                        new Seq<Pair<CharSequence, CharSequence>>(
+                                new ValuePair<CharSequence, CharSequence>("key1", "valueäöü"),
+                                new ValuePair<CharSequence, CharSequence>("key2", "value/+ "))).contentLength(),
+                isPresent((long) "key1=value%C3%A4%C3%B6%C3%BC&key2=value%2F%2B+".getBytes("UTF-8").length));
+    }
+
+
+    @Test
+    public void testEmptyContent() throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new XWwwFormUrlEncodedEntity(new EmptyIterable<Pair<CharSequence, CharSequence>>()).writeContent(out);
+        assertThat(out.toByteArray(), is("".getBytes("utf-8")));
+    }
+
+
+    @Test
+    public void testUtf8Content() throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new XWwwFormUrlEncodedEntity(new Seq<Pair<CharSequence, CharSequence>>(new ValuePair<CharSequence, CharSequence>("key", "valueäöü"))).writeContent(out);
+        assertThat(out.toByteArray(), is("key=value%C3%A4%C3%B6%C3%BC".getBytes("utf-8")));
+    }
+
+
+    @Test
+    public void testUtf8Content2() throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new XWwwFormUrlEncodedEntity(new Seq<Pair<CharSequence, CharSequence>>(
+                new ValuePair<CharSequence, CharSequence>("key1", "valueäöü"),
+                new ValuePair<CharSequence, CharSequence>("key2", "value/+ "))).writeContent(out);
+        assertThat(out.toByteArray(), is("key1=value%C3%A4%C3%B6%C3%BC&key2=value%2F%2B+".getBytes("utf-8")));
+    }
+}


### PR DESCRIPTION
This adds
* `JsonRequestEntity` to send `JSONObject`s or `JSONArray`s
* `TextRequestEntity` to send plain text
* `XWwwFormUrlEncodedEntity` to send `x-www-form-urlencoded` key-value pairs