### PR TITLE
tolerate absent getContentLengthLong method, fixes #114

### DIFF
--- a/httpurlconnection-executor/src/main/java/org/dmfs/httpessentials/httpurlconnection/HttpUrlConnectionResponseEntity.java
+++ b/httpurlconnection-executor/src/main/java/org/dmfs/httpessentials/httpurlconnection/HttpUrlConnectionResponseEntity.java
@@ -57,7 +57,16 @@ final class HttpUrlConnectionResponseEntity implements HttpResponseEntity
     @Override
     public Optional<Long> contentLength()
     {
-        long length = mConnection.getContentLengthLong();
+        long length;
+        try
+        {
+            length = mConnection.getContentLengthLong();
+        }
+        catch (NoSuchMethodError e)
+        {
+            // getContentLengthLong has been added in Java 7 and Android SDK 24, fall back to integer on older runtime engines
+            length = mConnection.getContentLength();
+        }
         return length < 0 ? Absent.<Long>absent() : new Present<>(length);
     }
 


### PR DESCRIPTION
There doesn't seem to be an easy check for the presence of a method. So we just fall back to getContentLenght if getContentLengthLong doesn't exist.